### PR TITLE
Do currency conversion for all grouped totals on the dashboard

### DIFF
--- a/front/components/dashboard/dashboard-category-totals/dashboard-category-totals.vue
+++ b/front/components/dashboard/dashboard-category-totals/dashboard-category-totals.vue
@@ -46,15 +46,7 @@ const dataStore = useDataStore()
 
 const barsList = computed(() => {
 
-  let dictionary = dataStore.transactionsListExpense.reduce((result, transaction) => {
-    let categoryId = Transaction.getCategoryId(transaction)
-
-
-    let amount = Transaction.getAmount(transaction)
-    let oldTotal = get(result, categoryId, 0)
-    result[categoryId] = oldTotal + amount
-    return result
-  }, {})
+  let dictionary = dataStore.dashboardExpensesByCategory
 
   let maxAmount = Math.max(...Object.values(dictionary))
 

--- a/front/components/dashboard/dashboard-tag-totals/dashboard-tag-totals.vue
+++ b/front/components/dashboard/dashboard-tag-totals/dashboard-tag-totals.vue
@@ -45,20 +45,12 @@ const dataStore = useDataStore()
 
 const barsList = computed(() => {
 
-  let tagTotalDictionary = dataStore.transactionsListExpense.reduce((result, transaction) => {
-    let targetTag = Transaction.getTags(transaction).find(tag => get(tag, 'attributes.parent_id') === null)
-    let tagId = get(targetTag, 'id', 0)
+  const tagTotalDictionary = dataStore.dashboardExpensesByTag
 
-    let amount = Transaction.getAmount(transaction)
-    let oldTotal = get(result, tagId, 0)
-    result[tagId] = oldTotal + amount
-    return result
-  }, {})
+  const maxAmount = Math.max(...Object.values(tagTotalDictionary))
 
-  let maxAmount = Math.max(...Object.values(tagTotalDictionary))
-
-  let bars = Object.keys(tagTotalDictionary).map(tagId => {
-    let tag = dataStore.tagDictionaryById[tagId]
+  const bars = Object.keys(tagTotalDictionary).map(tagId => {
+    const tag = dataStore.tagDictionaryById[tagId]
     const amount = tagTotalDictionary[tagId].toFixed(0)
     const percent = (amount / maxAmount) * 100
     return {

--- a/front/models/Transaction.js
+++ b/front/models/Transaction.js
@@ -90,6 +90,10 @@ class Transaction extends BaseModel {
     }, 0)
   }
 
+  static getCurrency (transaction) {
+    return get(transaction, 'attributes.transactions.0.currency_code', [])
+  }
+
   static getTags (transaction) {
     return get(transaction, 'attributes.transactions.0.tags', [])
   }

--- a/front/stores/dataStore.js
+++ b/front/stores/dataStore.js
@@ -19,7 +19,7 @@ import Transaction from '~/models/Transaction'
 import TransactionTransformer from '~/transformers/TransactionTransformer'
 import { listToTree, setLevel, sortByPath, treeToList } from '~/utils/DataUtils'
 import Tag from '~/models/Tag.js'
-import { convertAmount, transactionAmountInAccountCurrency, transactionsTotalInAccountCurrency } from '~/utils/CurrencyUtils'
+import { convertCurrency, convertTransactionAmountToCurrency, convertTransactionsTotalAmountToCurrency } from '~/utils/CurrencyUtils'
 
 export const useDataStore = defineStore('data', {
   state: () => {
@@ -92,11 +92,10 @@ export const useDataStore = defineStore('data', {
 
       return Object.keys(this.dashboardAccountsTotalByCurrency).reduce((result, currencyCode) => {
         const currencyAmount = this.dashboardAccountsTotalByCurrency[currencyCode]
-        return result + convertAmount(
+        return result + convertCurrency(
           currencyAmount,
           currencyCode,
           state.accountTotalCurrency,
-          state.exchangeRates
         )
       }, 0).toFixed(0)
     },
@@ -106,7 +105,7 @@ export const useDataStore = defineStore('data', {
         let categoryId = Transaction.getCategoryId(transaction)
     
         let oldTotal = get(result, categoryId, 0)
-        result[categoryId] = oldTotal + transactionAmountInAccountCurrency(transaction, state.accountTotalCurrency, state.exchangeRates)
+        result[categoryId] = oldTotal + convertTransactionAmountToCurrency(transaction, state.accountTotalCurrency)
 
         return result
       }, {})
@@ -118,7 +117,7 @@ export const useDataStore = defineStore('data', {
         let tagId = get(targetTag, 'id', 0)
     
         let oldTotal = get(result, tagId, 0)
-        result[tagId] = oldTotal + transactionAmountInAccountCurrency(transaction, state.accountTotalCurrency, state.exchangeRates)
+        result[tagId] = oldTotal + convertTransactionAmountToCurrency(transaction, state.accountTotalCurrency)
         return result
       }, {})
     },
@@ -142,7 +141,7 @@ export const useDataStore = defineStore('data', {
         const date = DateUtils.dateToString(Transaction.getDate(transaction))
 
         const oldValue = get(result, date, 0)
-        result[date] = oldValue + transactionAmountInAccountCurrency(transaction, state.accountTotalCurrency, state.exchangeRates)
+        result[date] = oldValue + convertTransactionAmountToCurrency(transaction, state.accountTotalCurrency)
 
         return result
       }, {})
@@ -161,15 +160,15 @@ export const useDataStore = defineStore('data', {
     },
 
     totalExpenseThisMonth (state) {
-      return transactionsTotalInAccountCurrency(this.transactionsListExpense, state.accountTotalCurrency, state.exchangeRates)
+      return convertTransactionsTotalAmountToCurrency(this.transactionsListExpense, state.accountTotalCurrency)
     },
 
     totalIncomeThisMonth (state) {
-      return transactionsTotalInAccountCurrency(this.transactionsListIncome, state.accountTotalCurrency, state.exchangeRates)
+      return convertTransactionsTotalAmountToCurrency(this.transactionsListIncome, state.accountTotalCurrency)
     },
 
     totalTransfersThisMonth (state) {
-      return transactionsTotalInAccountCurrency(this.transactionsListTransfers, state.accountTotalCurrency, state.exchangeRates)
+      return convertTransactionsTotalAmountToCurrency(this.transactionsListTransfers, state.accountTotalCurrency)
     },
 
     totalSurplusThisMonth (state) {

--- a/front/utils/CurrencyUtils.js
+++ b/front/utils/CurrencyUtils.js
@@ -1,0 +1,26 @@
+import { get } from 'lodash'
+import Transaction from '~/models/Transaction'
+
+export function convertAmount(amount, fromCurrency, toCurrency, exchangeRates) {
+  const exchangeSource = get(exchangeRates, `rates.${fromCurrency}`)
+  const exchangeDestination = get(exchangeRates, `rates.${toCurrency}`)
+  return (1.0 * amount * exchangeDestination) / exchangeSource
+}
+
+export function transactionAmountInAccountCurrency (transaction, accountCurrency, exchangeRates) {
+  const amount = Transaction.getAmount(transaction)
+  const currency = Transaction.getCurrency(transaction)
+
+  return convertAmount(
+    amount,
+    currency,
+    accountCurrency,
+    exchangeRates,
+  )
+}
+
+export function transactionsTotalInAccountCurrency (transactions, accountCurrency, exchangeRates) {
+  return transactions.reduce((total, transaction) => {
+    return total + transactionAmountInAccountCurrency(transaction, accountCurrency, exchangeRates)
+  }, 0);
+}

--- a/front/utils/CurrencyUtils.js
+++ b/front/utils/CurrencyUtils.js
@@ -1,26 +1,27 @@
 import { get } from 'lodash'
 import Transaction from '~/models/Transaction'
 
-export function convertAmount(amount, fromCurrency, toCurrency, exchangeRates) {
-  const exchangeSource = get(exchangeRates, `rates.${fromCurrency}`)
-  const exchangeDestination = get(exchangeRates, `rates.${toCurrency}`)
+export function convertCurrency(amount, fromCurrency, toCurrency) {
+  const dataStore = useDataStore()
+
+  const exchangeSource = get(dataStore.exchangeRates, `rates.${fromCurrency}`)
+  const exchangeDestination = get(dataStore.exchangeRates, `rates.${toCurrency}`)
   return (1.0 * amount * exchangeDestination) / exchangeSource
 }
 
-export function transactionAmountInAccountCurrency (transaction, accountCurrency, exchangeRates) {
+export function convertTransactionAmountToCurrency (transaction, accountCurrency) {
   const amount = Transaction.getAmount(transaction)
   const currency = Transaction.getCurrency(transaction)
 
-  return convertAmount(
+  return convertCurrency(
     amount,
     currency,
     accountCurrency,
-    exchangeRates,
   )
 }
 
-export function transactionsTotalInAccountCurrency (transactions, accountCurrency, exchangeRates) {
+export function convertTransactionsTotalAmountToCurrency (transactions, accountCurrency) {
   return transactions.reduce((total, transaction) => {
-    return total + transactionAmountInAccountCurrency(transaction, accountCurrency, exchangeRates)
+    return total + convertTransactionAmountToCurrency(transaction, accountCurrency)
   }, 0);
 }


### PR DESCRIPTION
Fixes #15

Added some helpers for converting currencies whereever it makes sense. Not particularly happy about the way I had to pass state into helper functions but looks like `useFoo()` cannot just be used anywhere.

Checked that there are no more crazy numbers because of summing transactions in different currencies.