### PR TITLE
Allow setting query timeout via env

### DIFF
--- a/front/nuxt.config.ts
+++ b/front/nuxt.config.ts
@@ -8,6 +8,7 @@ export default defineNuxtConfig({
   runtimeConfig: {
     public: {
       version: pkg.version,
+      queryTimeout: 4000,
       // mihai: 'test'
     },
   },

--- a/front/plugins/axios.js
+++ b/front/plugins/axios.js
@@ -18,7 +18,7 @@ axios.interceptors.request.use(
     }
 
     config.headers['Authorization'] = `Bearer ${authToken}`
-    config.timeout = 4000
+    config.timeout = appStore.queryTimeout
     return config
   },
   (error) => {

--- a/front/stores/appStore.js
+++ b/front/stores/appStore.js
@@ -18,6 +18,7 @@ export const useAppStore = defineStore('app', {
 
     return {
       currentAppVersion: runtimeConfig.public.version,
+      queryTimeout: runtimeConfig.public.queryTimeout,
       latestAppVersion: null,
 
       darkTheme: useLocalStorage('darkTheme', false),


### PR DESCRIPTION
You may want to configure it to account for slow Firefly endpoints.

Checked that this command produces expected results:
```
NUXT_PUBLIC_QUERY_TIMEOUT=10000 npm start
```
Hopefully passing env via Docker will work as well.