### PR TITLE
Fixed back navigation on exchange rates page

### DIFF
--- a/front/pages/exchange-rates/index.vue
+++ b/front/pages/exchange-rates/index.vue
@@ -53,6 +53,6 @@ UIUtils.showLoadingWhen(isRefreshing)
 const toolbar = useToolbar()
 toolbar.init({
   title: 'Exchange rates',
-  backRoute: RouteConstants.ROUTE_SETTINGS,
+  backRoute: RouteConstants.ROUTE_EXTRAS,
 })
 </script>


### PR DESCRIPTION
It's under Extras, not Settings