### PR TITLE
Show dashboard visible accounts on top

### DIFF
--- a/front/components/dashboard/dashboard-accounts/dashboard-accounts.vue
+++ b/front/components/dashboard/dashboard-accounts/dashboard-accounts.vue
@@ -71,16 +71,16 @@ const toggleHiddenAccounts = () => {
 }
 
 const visibleDashboardAccounts = computed(() => {
-  const visibleAccounts = []
-  const hiddenAccounts = []
-  dataStore.dashboardAccounts.forEach((account) => {
-    if (Account.getIsVisibleOnDashboard(account)) {
-      visibleAccounts.push(account)
+  const sortedAccounts = dataStore.dashboardAccounts.sort((a, b) => {
+    const aVisible = Account.getIsVisibleOnDashboard(a)
+    const bVisible = Account.getIsVisibleOnDashboard(b)
+    if (aVisible === bVisible) {
+      return 0
     } else {
-      hiddenAccounts.push(account)
+      return aVisible ? -1 : 1
     }
   })
-  return showHiddenAccounts.value ? [...visibleAccounts, ...hiddenAccounts] : visibleAccounts
+  return showHiddenAccounts.value ? sortedAccounts : sortedAccounts.filter((account) => Account.getIsVisibleOnDashboard(account))
 })
 
 const hasHiddenAccounts = computed(() => dataStore.dashboardAccounts.some((account) => !Account.getIsVisibleOnDashboard(account)))

--- a/front/components/dashboard/dashboard-accounts/dashboard-accounts.vue
+++ b/front/components/dashboard/dashboard-accounts/dashboard-accounts.vue
@@ -71,7 +71,16 @@ const toggleHiddenAccounts = () => {
 }
 
 const visibleDashboardAccounts = computed(() => {
-  return showHiddenAccounts.value ? dataStore.dashboardAccounts : dataStore.dashboardAccounts.filter((account) => Account.getIsVisibleOnDashboard(account))
+  const visibleAccounts = []
+  const hiddenAccounts = []
+  dataStore.dashboardAccounts.forEach((account) => {
+    if (Account.getIsVisibleOnDashboard(account)) {
+      visibleAccounts.push(account)
+    } else {
+      hiddenAccounts.push(account)
+    }
+  })
+  return showHiddenAccounts.value ? [...visibleAccounts, ...hiddenAccounts] : visibleAccounts
 })
 
 const hasHiddenAccounts = computed(() => dataStore.dashboardAccounts.some((account) => !Account.getIsVisibleOnDashboard(account)))


### PR DESCRIPTION
Currently if you mark some accounts as not dashboard-visible, things jump around when toggling see more/less.
With this change hidden accounts always appear at the bottom rather than in-between visible ones.