### PR TITLE
Show dashboard visible checkmark when there is no data

### DIFF
--- a/front/transformers/AccountTransformer.js
+++ b/front/transformers/AccountTransformer.js
@@ -23,6 +23,8 @@ export default class AccountTransformer extends ApiTransformer {
     item.attributes.currency = currencyDictionary[currencyId]
     item.attributes.icon = Icon.getIcon(get(item, 'attributes.icon'))
 
+    item.attributes.is_dashboard_visible = get(item, 'attributes.is_dashboard_visible', true)
+
     return item
   }
 


### PR DESCRIPTION
When there is no data for this field, account page shows no checkmark even though it's functionally `true`. It also requires toggling back and force to actually save the `false` value.
This PR fixes it by making account page display value consistent with `Account.getIsVisibleOnDashboard()`