### PR TITLE
Reduce docker img size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,28 +33,59 @@ COPY front .
 
 
 RUN npm install \
-    && npm run build \
-    && tar --owner=www-data --group=www-data --exclude=.git -czf /tmp/app-front.tar.gz .
+    && npm run build
 
+RUN npm cache clean --force
 
-# ================================
+RUN tar --owner=www-data --group=www-data \
+    --exclude=.git \
+    --exclude=.nuxt \
+    --exclude=.cache \
+    --exclude=node_modules/eslint-plugin-vue \
+    --exclude=node_modules/esbuild \
+    --exclude=node_modules/date-fns \
+    --exclude=node_modules/csso \
+    --exclude=node_modules/node-gyp \
+    --exclude=node_modules/vite \
+    --exclude=node_modules/@npmcli \
+    --exclude=node_modules/caniuse-lite \
+    --exclude=node_modules/vite-plugin-inspect \
+    --exclude=node_modules/@eslint \
+    --exclude=node_modules/lodash \
+    --exclude=node_modules/nuxi \
+    --exclude=node_modules/@unocss \
+    --exclude=node_modules/eslint* \
+    --exclude=node_modules/@rollup \
+    --exclude=node_modules/prettier \
+    --exclude=node_modules/@esbuild \
+    --exclude=node_modules/workbox-build \
+    --exclude=node_modules/es-abstract \
+    --exclude=node_modules/shiki \
+    --exclude=node_modules/@nuxt \
+    --exclude=node_modules/@typescript-eslint \
+    --exclude=node_modules/@vue/devtools* \
+    --exclude=node_modules/vant \
+    --exclude=node_modules/mathjs \
+    --exclude=node_modules/typescript \
+    --exclude=node_modules/@faker-js \
+    --exclude=node_modules/@opentelemetry \
+    node_modules/@babel/parser \
+    --exclude=node_modules/@babel \
+    --exclude=node_modules/@tabler \
+    -czf /tmp/app-front.tar.gz .
+    # ================================
 
-FROM ${REGISTRY}/php:${LARAVEL_ALPINE_VERSION}-build
+    FROM ${REGISTRY}/php:${LARAVEL_ALPINE_VERSION}-build
 
-WORKDIR /var/www/html
+    WORKDIR /var/www/html
 
-COPY --from=build-container /tmp/app-back.tar.gz .
-
-RUN tar -xf app-back.tar.gz \
-    && rm -rf app-back.tar.gz
+    RUN --mount=type=bind,from=build-container,source=/tmp/,target=/build \
+    tar -xf /build/app-back.tar.gz -C .
 
 WORKDIR /var/www/html/front
 
-COPY --from=build-container /tmp/app-front.tar.gz .
-
-RUN tar -xf app-front.tar.gz \
-    && rm -rf app-front.tar.gz
-
+RUN --mount=type=bind,from=build-container,source=/tmp/,target=/build \
+    tar -xf /build/app-front.tar.gz -C .
 
 COPY docker/conf/supervisor/node.ini /etc/supervisor.d
 COPY docker/conf/nginx/default.conf /etc/nginx/http.d


### PR DESCRIPTION
an attempt to reduce the docker img size.

 `:latest` is currently 600MB+ 

Reducing the no. of unused `node_modules` being copied over + removing some build caches reduces the image size to about 360MB

I have no experience with any of the used packages/software but with some trial and error this config seems to be fully functional.

what do you think?