### PR TITLE
reduce image size

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -17,17 +17,17 @@
     "lint:prettier:fix": "prettier --write --list-different ."
   },
   "devDependencies": {
-    "@faker-js/faker": "^8.4.1",
-    "@nuxt/eslint": "^0.3.10",
-    "@nuxtjs/device": "^3.1.1",
-    "@vant/nuxt": "^1.0.4",
-    "@vite-pwa/nuxt": "^0.7.0",
     "eslint-config-prettier": "^9.1.0",
-    "nuxt": "^3.11.2",
-    "nuxt-svgo": "^4.0.0",
     "prettier": "^3.2.5"
   },
   "dependencies": {
+    "@nuxt/eslint": "^0.3.10",
+    "@faker-js/faker": "^8.4.1",
+    "@nuxtjs/device": "^3.1.1",
+    "nuxt": "^3.11.2",
+    "nuxt-svgo": "^4.0.0",
+    "@vite-pwa/nuxt": "^0.7.0",
+    "@vant/nuxt": "^1.0.4",
     "@pinia/nuxt": "^0.5.1",
     "@tabler/icons-vue": "^3.1.0",
     "@vant/touch-emulator": "^1.4.0",


### PR DESCRIPTION
Trying to get more grip on the image size. 
Looking into running `npm install --omit=dev` which then obviously doesn't install dev dependencies.

Looks like the dev list was off though. I can't get it to install unless i move these packages to dependencies. Seems odd for the \@nuxt/eslint.

Anyway, it's something but won't change much. 

I still don't understand `npm`, `nuxt` or `laravel` so i don't understand how these dependencies hook into each other. Maybe you can have a look of these change actually make sense?

ps. this does actually build with changing the dockerfile to `npm install --omit=dev`
Still needs that custom exclude command to keep the size down though
