### PR TITLE
Fixed icon selector when there is no value

### DIFF
--- a/front/components/select/icon-select.vue
+++ b/front/components/select/icon-select.vue
@@ -12,7 +12,7 @@
   >
     <template #input>
       <div v-if="!modelValue" class="text-muted">No icon</div>
-      <app-icon :icon="modelValue.icon" style="width: 25px"/>
+      <app-icon v-else :icon="modelValue.icon" style="width: 25px"/>
     </template>
 
     <template #item="{ item }">


### PR DESCRIPTION
This was accidentally deleted in one of the dark mode commits

Fixes #63 