### PR TITLE
Correct DB_PORT on compose example

### DIFF
--- a/docker-compose.pico+firefly+importer.yml
+++ b/docker-compose.pico+firefly+importer.yml
@@ -13,7 +13,7 @@ services:
       - FIREFLY_URL=http://firefly-app:8080
       - DB_CONNECTION=pgsql
       - DB_HOST=firefly-pico-postgresql
-      - DB_PORT=54322
+      - DB_PORT=5432
       - DB_DATABASE=firefly-pico
       - DB_USERNAME=firefly-pico
       - DB_PASSWORD=very-secure-pwd-pico

--- a/docker-compose.pico+firefly.yml
+++ b/docker-compose.pico+firefly.yml
@@ -13,7 +13,7 @@ services:
       - FIREFLY_URL=http://firefly-app:8080
       - DB_CONNECTION=pgsql
       - DB_HOST=firefly-pico-postgresql
-      - DB_PORT=54322
+      - DB_PORT=5432
       - DB_DATABASE=firefly-pico
       - DB_USERNAME=firefly-pico
       - DB_PASSWORD=very-secure-pwd-pico


### PR DESCRIPTION
Corrected what I am assuming is a typo on the `docker-compose` example which caused errors deploying from this template.