### PR TITLE
Fix for error: Credit card type is mandatory when account type is cre…

### DIFF
--- a/front/transformers/AccountTransformer.js
+++ b/front/transformers/AccountTransformer.js
@@ -40,6 +40,8 @@ export default class AccountTransformer extends ApiTransformer {
       icon: get(data, 'icon.icon'),
       type: get(data, 'type.fireflyCode'),
       account_role: get(data, 'account_role.fireflyCode'),
+      credit_card_type: get(data, 'credit_card_type'),
+      monthly_payment_date: get(data, 'monthly_payment_date'),
       currency_id: get(data, 'currency.id'),
       currency_code: get(data, 'currency.attributes.code'),
 

--- a/front/transformers/AccountTransformer.js
+++ b/front/transformers/AccountTransformer.js
@@ -34,13 +34,13 @@ export default class AccountTransformer extends ApiTransformer {
     }
 
     let data = _.get(item, 'attributes')
-    let cc_type = get(data, 'credit_card_type')
-    if (cc_type == null) {
-      cc_type = 'monthlyFull'
+    let creditCardType = get(data, 'credit_card_type')
+    if (creditCardType == null) {
+      creditCardType = 'monthlyFull'
     }
-    let payment_date = get(data, 'monthly_payment_date')
-    if (payment_date == null) {
-      payment_date = '0001-01-01T00:00:00+01:34'
+    let monthlyPaymentDate = get(data, 'monthly_payment_date')
+    if (monthlyPaymentDate == null) {
+      monthlyPaymentDate = '0001-01-01T00:00:00+01:34'
     }
     
     return {
@@ -48,8 +48,8 @@ export default class AccountTransformer extends ApiTransformer {
       icon: get(data, 'icon.icon'),
       type: get(data, 'type.fireflyCode'),
       account_role: get(data, 'account_role.fireflyCode'),
-      credit_card_type:  cc_type,
-      monthly_payment_date: payment_date,
+      credit_card_type:  creditCardType,
+      monthly_payment_date: monthlyPaymentDate,
       currency_id: get(data, 'currency.id'),
       currency_code: get(data, 'currency.attributes.code'),
 

--- a/front/transformers/AccountTransformer.js
+++ b/front/transformers/AccountTransformer.js
@@ -34,14 +34,22 @@ export default class AccountTransformer extends ApiTransformer {
     }
 
     let data = _.get(item, 'attributes')
-
+    let cc_type = get(data, 'credit_card_type')
+    if (cc_type == null) {
+      cc_type = 'monthlyFull'
+    }
+    let payment_date = get(data, 'monthly_payment_date')
+    if (payment_date == null) {
+      payment_date = '0001-01-01T00:00:00+01:34'
+    }
+    
     return {
       name: get(data, 'name', ''),
       icon: get(data, 'icon.icon'),
       type: get(data, 'type.fireflyCode'),
       account_role: get(data, 'account_role.fireflyCode'),
-      credit_card_type: get(data, 'credit_card_type'),
-      monthly_payment_date: get(data, 'monthly_payment_date'),
+      credit_card_type:  cc_type,
+      monthly_payment_date: payment_date,
       currency_id: get(data, 'currency.id'),
       currency_code: get(data, 'currency.attributes.code'),
 


### PR DESCRIPTION
When you try to update an account with role credit card, an error pops up because the credit card type and monthly payment date are mandatory parameters for account role credit card. 
That's probably a requirement comming from the firefly API. Strangely enough, on firefly web app you can save an account with role credit card and without a monthly payment date which will still cause an error when you save such account on PICO, saying that a monthly payment date is mandatory. I think that's an issue with firefly API. I guess it shouldn't be mandatory in the API if you can save it without a monthly payment date from the web app.
For this fix I just added the two mandatory fields in the transpormation to API. If they are also maintained from firefly it should work.