### PR TITLE
Only filter out zero-amount accounts when corresponding settings is enabled

### DIFF
--- a/front/stores/dataStore.js
+++ b/front/stores/dataStore.js
@@ -74,7 +74,7 @@ export const useDataStore = defineStore('data', {
         return isEqual(Account.getType(account), Account.types.asset) &&
           Account.getIsActive(account) &&
           Account.getIsIncludedInNetWorth(account) &&
-          (Account.getBalance(account) > 0 || appStore.dashboard.areEmptyAccountsVisible)
+          (Account.getBalance(account) != 0 || appStore.dashboard.areEmptyAccountsVisible)
       })
     },
 


### PR DESCRIPTION
Currently we filter out negative amount accounts such as loans and credit cards.
Even worse, it actually affects displayed net worth.