### PR TITLE
Improve sync settings to DB

### DIFF
--- a/back/app/Models/Profile.php
+++ b/back/app/Models/Profile.php
@@ -6,9 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class Profile extends Model
 {
-    protected $primaryKey = 'auth_token_hash';
 
-    protected $keyType = 'string';
 
     protected $fillable = [
         'auth_token_hash',

--- a/back/database/migrations/2024_06_25_000000_create_profiles_table.php
+++ b/back/database/migrations/2024_06_25_000000_create_profiles_table.php
@@ -4,16 +4,15 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class extends Migration {
 
     public function up(): void
     {
         Schema::create('profiles', function (Blueprint $table) {
-            $table->string("auth_token_hash")->primary();
-            $table->timestamps();
-
+            $table->id();
+            $table->string("auth_token_hash")->unique();
             $table->jsonb('settings')->default('{}');
+            $table->timestamps();
         });
     }
 

--- a/front/app.vue
+++ b/front/app.vue
@@ -22,7 +22,7 @@ let appStore = useAppStore()
 const theme = computed(() => (profileStore.darkTheme ? 'dark' : 'white'))
 
 onMounted(async () => {
-  if (!profileStore.authToken) {
+  if (!appStore.authToken) {
     navigateTo(`${RouteConstants.ROUTE_SETTINGS_APP_CONFIG}`)
     return
   }

--- a/front/app.vue
+++ b/front/app.vue
@@ -16,18 +16,20 @@ import '~/assets/styles/variables.css'
 import AppLoading from '~/components/ui-kit/app-loading.vue'
 
 let dataStore = useDataStore()
+let profileStore = useProfileStore()
 let appStore = useAppStore()
 
-const theme = computed(() => (appStore.darkTheme ? 'dark' : 'white'))
+const theme = computed(() => (profileStore.darkTheme ? 'dark' : 'white'))
 
 onMounted(async () => {
-  if (!appStore.authToken) {
+  if (!profileStore.authToken) {
     navigateTo(`${RouteConstants.ROUTE_SETTINGS_APP_CONFIG}`)
     return
   }
 
+  appStore.fetchLatestAppVersion()
+  await profileStore.fetchProfile()
   await dataStore.syncEverythingIfOld()
-  await appStore.syncEverything()
 })
 
 const { isLoading } = storeToRefs(dataStore)

--- a/front/components/dashboard/dashboard-accounts/dashboard-accounts.vue
+++ b/front/components/dashboard/dashboard-accounts/dashboard-accounts.vue
@@ -13,7 +13,7 @@
 
       <van-button @click="onToggleShowDashboardAccountValues" size="small" class="mr-10">
         <template #icon>
-          <app-icon :icon="appStore.dashboard.showAccountAmounts ? 'IconEyeX' : 'IconEye'" :size="20" />
+          <app-icon :icon="profileStore.dashboard.showAccountAmounts ? 'IconEyeX' : 'IconEye'" :size="20" />
           <!--              <van-icon name="eye-o"/>-->
         </template>
       </van-button>
@@ -62,7 +62,7 @@ import RouteConstants from '~/constants/RouteConstants.js'
 import { IconCash } from '@tabler/icons-vue'
 import { getFormattedValue } from '~/utils/MathUtils.js'
 
-const appStore = useAppStore()
+const profileStore = useProfileStore()
 const dataStore = useDataStore()
 
 const showHiddenAccounts = ref(false)
@@ -82,9 +82,9 @@ const accountTotal = computed(() => {
 })
 
 const onToggleShowDashboardAccountValues = async () => {
-  appStore.dashboard.showAccountAmounts = !appStore.dashboard.showAccountAmounts
+  profileStore.dashboard.showAccountAmounts = !profileStore.dashboard.showAccountAmounts
 
-  await appStore.writeProfile()
+  await profileStore.writeProfile()
 }
 
 const getAccountAmount = (account) => {

--- a/front/components/dashboard/dashboard-accounts/dashboard-accounts.vue
+++ b/front/components/dashboard/dashboard-accounts/dashboard-accounts.vue
@@ -83,8 +83,6 @@ const accountTotal = computed(() => {
 
 const onToggleShowDashboardAccountValues = async () => {
   profileStore.dashboard.showAccountAmounts = !profileStore.dashboard.showAccountAmounts
-
-  await profileStore.writeProfile()
 }
 
 const getAccountAmount = (account) => {

--- a/front/components/dashboard/dashboard-summary/dashboard-summary.vue
+++ b/front/components/dashboard/dashboard-summary/dashboard-summary.vue
@@ -45,11 +45,11 @@ import { addMonths, differenceInDays, startOfDay, subDays, subMonths } from 'dat
 import RouteConstants from '~/constants/RouteConstants.js'
 import Transaction from '~/models/Transaction.js'
 
-const appStore = useAppStore()
+const profileStore = useProfileStore()
 const dataStore = useDataStore()
 
 const startDate = computed(() => {
-  let dateCurrentMonth = startOfDay(new Date()).setDate(appStore.dashboard.firstDayOfMonth)
+  let dateCurrentMonth = startOfDay(new Date()).setDate(profileStore.dashboard.firstDayOfMonth)
   return dateCurrentMonth > new Date() ? subMonths(dateCurrentMonth, 1) : dateCurrentMonth
 })
 
@@ -68,7 +68,7 @@ const remainingDays = computed(() => {
 })
 
 // const getFormattedValue = (value) => {
-//   if (!appStore.dashboard.showAccountAmounts) {
+//   if (!profileStore.dashboard.showAccountAmounts) {
 //     return  '******'
 //   }
 //   return new Intl.NumberFormat('de-DE', {minimumFractionDigits: 2, maximumFractionDigits: 2}).format(value)

--- a/front/components/list-items/transaction-list-item-hero-icon.vue
+++ b/front/components/list-items/transaction-list-item-hero-icon.vue
@@ -33,7 +33,7 @@ const props = defineProps({
   value: Object,
 })
 
-const appStore = useAppStore()
+const profileStore = useProfileStore()
 const dataStore = useDataStore()
 
 const emit = defineEmits(['onEdit', 'onDelete'])
@@ -83,11 +83,11 @@ const categoryIcon = computed(() => {
   return get(category, 'attributes.icon.icon') ?? TablerIconConstants.category
 })
 
-const isAccountIconVisible = computed(() => appStore.heroIcons.some((item) => item.code === HERO_ICONS.account))
-const isTagIconVisible = computed(() => appStore.heroIcons.some((item) => item.code === HERO_ICONS.tag) && !isEmpty(tags.value))
-const isCategoryIconVisible = computed(() => appStore.heroIcons.some((item) => item.code === HERO_ICONS.category))
-const isWeekdayIconVisible = computed(() => appStore.heroIcons.some((item) => item.code === HERO_ICONS.dayOfWeek))
-const isHourIconVisible = computed(() => appStore.heroIcons.some((item) => item.code === HERO_ICONS.hour))
+const isAccountIconVisible = computed(() => profileStore.heroIcons.some((item) => item.code === HERO_ICONS.account))
+const isTagIconVisible = computed(() => profileStore.heroIcons.some((item) => item.code === HERO_ICONS.tag) && !isEmpty(tags.value))
+const isCategoryIconVisible = computed(() => profileStore.heroIcons.some((item) => item.code === HERO_ICONS.category))
+const isWeekdayIconVisible = computed(() => profileStore.heroIcons.some((item) => item.code === HERO_ICONS.dayOfWeek))
+const isHourIconVisible = computed(() => profileStore.heroIcons.some((item) => item.code === HERO_ICONS.hour))
 
 const isAnyIconVisible = computed(() => {
   return isAccountIconVisible.value || isTagIconVisible.value || isCategoryIconVisible.value || isWeekdayIconVisible || isHourIconVisible

--- a/front/components/select/tag-select.vue
+++ b/front/components/select/tag-select.vue
@@ -55,11 +55,11 @@ import TablerIconConstants from '~/constants/TablerIconConstants'
 import { uniqBy } from 'lodash/array.js'
 
 const dataStore = useDataStore()
-const appStore = useAppStore()
+const profileStore = useProfileStore()
 const attrs = useAttrs()
 const { dynamicAttrs } = useFormAttributes(attrs)
 
-const { showTagSelectAsGrid } = storeToRefs(appStore)
+const { showTagSelectAsGrid } = storeToRefs(profileStore)
 
 const props = defineProps({
   label: {

--- a/front/components/transaction/transaction-amount-field.vue
+++ b/front/components/transaction/transaction-amount-field.vue
@@ -62,7 +62,7 @@ import { moveInputCursorToEnd, sleep } from '~/utils/VueUtils'
 import { evalMath, removeEndOperators, sanitizeAmount } from '~/utils/MathUtils' // import { useDevice } from '@nuxtjs/device'
 // import { useDevice } from '@nuxtjs/device'
 
-const appStore = useAppStore()
+const profileStore = useProfileStore()
 const dataStore = useDataStore()
 const attrs = useAttrs()
 
@@ -91,7 +91,7 @@ const input = ref(null)
 
 const { isMobile } = useDevice()
 
-const quickButtons = appStore.quickValueButtons
+const quickButtons = profileStore.quickValueButtons
 const operatorsList = ref(['+', '-', '*', '/'])
 
 const onQuickButton = async (quickButton) => {

--- a/front/components/transaction/transaction-assistant.vue
+++ b/front/components/transaction/transaction-assistant.vue
@@ -100,7 +100,7 @@ import { ellipsizeText } from '~/utils/Utils.js'
 const props = defineProps({})
 
 const dataStore = useDataStore()
-const appStore = useAppStore()
+const profileStore = useProfileStore()
 
 const emit = defineEmits(['change'])
 const show = ref(false)

--- a/front/components/ui-kit/app-loading.vue
+++ b/front/components/ui-kit/app-loading.vue
@@ -1,6 +1,6 @@
 <template>
   <transition name="fade">
-    <div v-if="appStore.isLoading" class="app-loading-background">
+    <div v-if="profileStore.isLoading" class="app-loading-background">
         <div class="app-loading flex-column flex-center">
           <icon-rotate :size="30" :stroke="1.4" class="animate-rotate-infinite" />
           <div class="text-size-16">Loading...</div>
@@ -13,7 +13,7 @@
 import { IconRotate } from '@tabler/icons-vue'
 import anime from 'animejs'
 
-const appStore = useAppStore()
+const profileStore = useProfileStore()
 
 // onMounted(async () => {
 //   await nextTick()

--- a/front/components/ui-kit/theme/app-bottom-loading.vue
+++ b/front/components/ui-kit/theme/app-bottom-loading.vue
@@ -14,11 +14,11 @@
 
 <script setup>
 import { useDataStore } from '~/stores/dataStore'
-import { useAppStore } from '~/stores/appStore'
+import { useProfileStore } from '~/stores/profileStore'
 import { IconRotateClockwise } from '@tabler/icons-vue'
 
 const dataStore = useDataStore()
-const appStore = useAppStore()
+const profileStore = useProfileStore()
 const route = useRoute()
 
 const onResync = async () => {

--- a/front/components/ui-kit/theme/app-bottom-toolbar.vue
+++ b/front/components/ui-kit/theme/app-bottom-toolbar.vue
@@ -39,13 +39,14 @@
 
 <script setup>
 import { useDataStore } from '~/stores/dataStore'
-import { useAppStore } from '~/stores/appStore'
+import { useProfileStore } from '~/stores/profileStore'
 import RouteConstants from '~/constants/RouteConstants'
 import TablerIconConstants from '~/constants/TablerIconConstants'
 import anime from 'animejs'
 import { animateBottomToolbarAddButton } from '~/utils/AnimationUtils.js'
 
 const dataStore = useDataStore()
+const profileStore = useProfileStore()
 const appStore = useAppStore()
 const route = useRoute()
 

--- a/front/components/ui-kit/theme/app-top-toolbar.vue
+++ b/front/components/ui-kit/theme/app-top-toolbar.vue
@@ -19,10 +19,10 @@
 </template>
 
 <script setup>
-import { useAppStore } from '~/stores/appStore'
+import { useProfileStore } from '~/stores/profileStore'
 import { useToolbar } from '~/composables/useToolbar'
 
-const appStore = useAppStore()
+const profileStore = useProfileStore()
 const { title, subtitle, onBack, leftText, backRoute, titleIcon } = useToolbar()
 
 const hasSubtitle = computed(() => !isStringEmpty(subtitle.value))

--- a/front/composables/useForm.js
+++ b/front/composables/useForm.js
@@ -15,7 +15,7 @@ export function useForm(props) {
   const repository = model.getRepository()
 
   // let dataStore = useDataStore()
-  // let appStore = useAppStore()
+  // let profileStore = useProfileStore()
   const route = useRoute()
 
   const title = computed(() => (route.params.id ? titleEdit : titleAdd))

--- a/front/models/Transaction.js
+++ b/front/models/Transaction.js
@@ -1,7 +1,7 @@
 import BaseModel from '~/models/BaseModel'
 import TransactionTransformer from '~/transformers/TransactionTransformer'
 import TransactionRepository from '~/repository/TransactionRepository'
-import { useAppStore } from '~/stores/appStore'
+import { useProfileStore } from '~/stores/profileStore'
 import Account from '~/models/Account'
 import _, { get, isEqual } from 'lodash'
 
@@ -15,12 +15,12 @@ class Transaction extends BaseModel {
   }
 
   getEmpty() {
-    const appStore = useAppStore()
+    const profileStore = useProfileStore()
 
     let type =
       Transaction.getTransactionTypeForAccounts({
-        source: appStore.defaultAccountSource,
-        destination: appStore.defaultAccountDestination,
+        source: profileStore.defaultAccountSource,
+        destination: profileStore.defaultAccountDestination,
       }) ?? Transaction.types.expense
     // let type = Transaction.typesList.find(item => item.code === transactionTypeCode)
     // let type = Transaction.types[transactionTypeCode]
@@ -37,13 +37,13 @@ class Transaction extends BaseModel {
             amount: '',
             // 'date': startOfDay(new Date()),
             date: date,
-            tags: appStore.defaultTags,
+            tags: profileStore.defaultTags,
             description: '',
             notes: '',
-            accountSource: appStore.defaultAccountSource,
-            accountDestination: appStore.defaultAccountDestination,
+            accountSource: profileStore.defaultAccountSource,
+            accountDestination: profileStore.defaultAccountDestination,
             type: type,
-            category: appStore.defaultCategory,
+            category: profileStore.defaultCategory,
           },
         ],
       },

--- a/front/pages/accounts/[[id]].vue
+++ b/front/pages/accounts/[[id]].vue
@@ -49,7 +49,7 @@ import { ref } from 'vue';
 import RouteConstants from '~/constants/RouteConstants'
 import { useDataStore } from '~/stores/dataStore'
 import { get } from 'lodash'
-import { useAppStore } from '~/stores/appStore'
+import { useProfileStore } from '~/stores/profileStore'
 import { ref } from 'vue'
 import { useForm } from '~/composables/useForm'
 import Account from '~/models/Account'
@@ -60,7 +60,7 @@ import { useToolbar } from '~/composables/useToolbar'
 import { avatarListIcons } from '~/constants/SvgConstants.js'
 
 let dataStore = useDataStore()
-let appStore = useAppStore()
+let profileStore = useProfileStore()
 const route = useRoute()
 
 const resetFields = () => {
@@ -115,7 +115,7 @@ const { name, type, role, currency, icon, includeNetWorth, isDashboardVisible } 
 const isRoleVisible = computed(() => get(type.value, 'fireflyCode') === Account.types.asset.fireflyCode)
 
 watch(name, (newValue) => {
-  if (!appStore.lowerCaseAccountName) {
+  if (!profileStore.lowerCaseAccountName) {
     return
   }
   name.value = newValue.toLowerCase()

--- a/front/pages/categories/[[id]].vue
+++ b/front/pages/categories/[[id]].vue
@@ -28,7 +28,7 @@ import { ref } from 'vue';
 import RouteConstants from '~/constants/RouteConstants'
 import { useDataStore } from '~/stores/dataStore'
 import _ from 'lodash'
-import { useAppStore } from '~/stores/appStore'
+import { useProfileStore } from '~/stores/profileStore'
 import { ref } from 'vue'
 import { useForm } from '~/composables/useForm'
 import { generateChildren } from '~/utils/VueUtils'
@@ -37,7 +37,7 @@ import { useToolbar } from '~/composables/useToolbar'
 import CategoryTransformer from '~/transformers/CategoryTransformer'
 
 let dataStore = useDataStore()
-let appStore = useAppStore()
+let profileStore = useProfileStore()
 const route = useRoute()
 
 const form = ref(null)
@@ -80,7 +80,7 @@ const { name, icon } = generateChildren(item, [
 ])
 
 watch(name, (newValue) => {
-  if (!appStore.lowerCaseCategoryName) {
+  if (!profileStore.lowerCaseCategoryName) {
     return
   }
   name.value = newValue.toLowerCase()

--- a/front/pages/currencies/[[id]].vue
+++ b/front/pages/currencies/[[id]].vue
@@ -33,7 +33,7 @@ import _ from 'lodash'
 import { startOfDay } from 'date-fns'
 import UIUtils from '~/utils/UIUtils'
 import DateUtils from '~/utils/DateUtils'
-import { useAppStore } from '~/stores/appStore'
+import { useProfileStore } from '~/stores/profileStore'
 import { ref } from 'vue'
 import AccountRepository from '~/repository/AccountRepository'
 import { useForm } from '~/composables/useForm'
@@ -45,7 +45,7 @@ import CurrencyTransformer from '~/transformers/CurrencyTransformer'
 import Currency from '~/models/Currency'
 
 let dataStore = useDataStore()
-let appStore = useAppStore()
+let profileStore = useProfileStore()
 const route = useRoute()
 
 const form = ref(null)

--- a/front/pages/dashboard.vue
+++ b/front/pages/dashboard.vue
@@ -18,8 +18,6 @@
   </div>
 </template>
 
-import { ref, onMounted } from 'vue'; import { useAppStore } from '~/stores/appStore'
-
 <script setup>
 import { useToolbar } from '~/composables/useToolbar'
 import { debounce } from 'lodash/function'
@@ -32,7 +30,7 @@ const toolbar = useToolbar()
 toolbar.init({ title: 'Dashboard' })
 
 const dataStore = useDataStore()
-const appStore = useAppStore()
+const profileStore = useProfileStore()
 const { isLoadingAccounts } = storeToRefs(dataStore)
 
 const onRefresh = () => {

--- a/front/pages/exchange-rates/index.vue
+++ b/front/pages/exchange-rates/index.vue
@@ -23,13 +23,13 @@
 
 <script setup>
 import { get } from 'lodash'
-import { useAppStore } from '~/stores/appStore'
+import { useProfileStore } from '~/stores/profileStore'
 import { useDataStore } from '~/stores/dataStore'
 import { useToolbar } from '~/composables/useToolbar'
 import RouteConstants from '~/constants/RouteConstants'
 import UIUtils from '~/utils/UIUtils.js'
 
-const appStore = useAppStore()
+const profileStore = useProfileStore()
 const dataStore = useDataStore()
 
 const isRefreshing = ref(false)

--- a/front/pages/extras.vue
+++ b/front/pages/extras.vue
@@ -22,10 +22,9 @@
   </div>
 </template>
 
-import { ref, onMounted } from 'vue'; import { useAppStore } from '~/stores/appStore'
 
 <script setup>
-import { useAppStore } from '~/stores/appStore'
+import { useProfileStore } from '~/stores/profileStore'
 import RouteConstants from '~/constants/RouteConstants'
 import { useToolbar } from '~/composables/useToolbar'
 import TablerIconConstants from '~/constants/TablerIconConstants'

--- a/front/pages/settings/about.vue
+++ b/front/pages/settings/about.vue
@@ -34,14 +34,14 @@
 </template>
 
 <script setup>
-import { useAppStore } from '~/stores/appStore'
+import { useProfileStore } from '~/stores/profileStore'
 import { useDataStore } from '~/stores/dataStore'
 import { useToolbar } from '~/composables/useToolbar'
 import RouteConstants from '~/constants/RouteConstants'
 import { REPO_URL } from '~/constants/Constants'
 import { onMounted } from 'vue'
 
-const appStore = useAppStore()
+const profileStore = useProfileStore()
 const dataStore = useDataStore()
 
 const toolbar = useToolbar()

--- a/front/pages/settings/app-config.vue
+++ b/front/pages/settings/app-config.vue
@@ -34,7 +34,7 @@
 
 <script setup>
 import { onMounted, ref } from 'vue'
-import { useAppStore } from '~/stores/appStore'
+import { useProfileStore } from '~/stores/profileStore'
 import { useDataStore } from '~/stores/dataStore'
 import UIUtils from '~/utils/UIUtils'
 import SettingsTokenField from '~/components/settings/settings-token-field.vue'
@@ -45,7 +45,7 @@ import AppConfigStat from '~/components/settings/app-config-stat.vue'
 import UserRepository from '~/repository/UserRepository'
 import TablerIconConstants from '~/constants/TablerIconConstants'
 
-const appStore = useAppStore()
+const profileStore = useProfileStore()
 const dataStore = useDataStore()
 
 const authToken = ref('')
@@ -63,15 +63,15 @@ const lastSync = computed(() => {
 })
 
 onMounted(() => {
-  authToken.value = appStore.authToken
-  picoBackendURL.value = appStore.picoBackendURL
+  authToken.value = profileStore.authToken
+  picoBackendURL.value = profileStore.picoBackendURL
 })
 
 const onSave = async () => {
   picoBackendURL.value = picoBackendURL.value.endsWith('/') ? picoBackendURL.value.slice(0, -1) : picoBackendURL.value
 
-  appStore.authToken = authToken.value
-  appStore.picoBackendURL = picoBackendURL.value
+  profileStore.authToken = authToken.value
+  profileStore.picoBackendURL = picoBackendURL.value
 
   UIUtils.showToastLoading('Checking configuration')
   let userResponse = await new UserRepository().getUser()

--- a/front/pages/settings/app-config.vue
+++ b/front/pages/settings/app-config.vue
@@ -45,7 +45,7 @@ import AppConfigStat from '~/components/settings/app-config-stat.vue'
 import UserRepository from '~/repository/UserRepository'
 import TablerIconConstants from '~/constants/TablerIconConstants'
 
-const profileStore = useProfileStore()
+const appStore = useAppStore()
 const dataStore = useDataStore()
 
 const authToken = ref('')
@@ -63,15 +63,15 @@ const lastSync = computed(() => {
 })
 
 onMounted(() => {
-  authToken.value = profileStore.authToken
-  picoBackendURL.value = profileStore.picoBackendURL
+  authToken.value = appStore.authToken
+  picoBackendURL.value = appStore.picoBackendURL
 })
 
 const onSave = async () => {
   picoBackendURL.value = picoBackendURL.value.endsWith('/') ? picoBackendURL.value.slice(0, -1) : picoBackendURL.value
 
-  profileStore.authToken = authToken.value
-  profileStore.picoBackendURL = picoBackendURL.value
+  appStore.authToken = authToken.value
+  appStore.picoBackendURL = picoBackendURL.value
 
   UIUtils.showToastLoading('Checking configuration')
   let userResponse = await new UserRepository().getUser()

--- a/front/pages/settings/app-config.vue
+++ b/front/pages/settings/app-config.vue
@@ -7,8 +7,8 @@
         <!--        <div class="van-cell-group-title">Setup</div>-->
 
         <app-field left-icon="link-o" v-model="picoBackendURL" label="Pico backend URL" :rules="[{ required: true, message: 'This field is required' }]" required />
-
         <settings-token-field v-model="authToken" required />
+        <app-boolean left-icon="points" label="Save settings in database, linked with token" v-model="syncProfileInDB" />
       </van-cell-group>
 
       <van-cell-group inset>
@@ -50,6 +50,7 @@ const dataStore = useDataStore()
 
 const authToken = ref('')
 const picoBackendURL = ref('')
+const syncProfileInDB = ref(true)
 
 const accountsCount = computed(() => dataStore.accountList.length)
 const categoriesCount = computed(() => dataStore.categoryList.length)
@@ -65,6 +66,7 @@ const lastSync = computed(() => {
 onMounted(() => {
   authToken.value = appStore.authToken
   picoBackendURL.value = appStore.picoBackendURL
+  syncProfileInDB.value = appStore.syncProfileInDB
 })
 
 const onSave = async () => {
@@ -72,6 +74,7 @@ const onSave = async () => {
 
   appStore.authToken = authToken.value
   appStore.picoBackendURL = picoBackendURL.value
+  appStore.syncProfileInDB = syncProfileInDB.value
 
   UIUtils.showToastLoading('Checking configuration')
   let userResponse = await new UserRepository().getUser()

--- a/front/pages/settings/index.vue
+++ b/front/pages/settings/index.vue
@@ -31,8 +31,6 @@
   </div>
 </template>
 
-import { ref, onMounted } from 'vue'; import { useAppStore } from '~/stores/appStore' import
-
 <script setup>
 import RouteConstants from '~/constants/RouteConstants'
 import { useToolbar } from '~/composables/useToolbar'
@@ -48,5 +46,4 @@ toolbar.init({ title: 'Settings' })
 onMounted(() => {
   animateSettings()
 })
-
 </script>

--- a/front/pages/settings/user-preferences-dashboard.vue
+++ b/front/pages/settings/user-preferences-dashboard.vue
@@ -23,13 +23,13 @@
 
 <script setup>
 import { onMounted, ref } from 'vue'
-import { useAppStore } from '~/stores/appStore'
+import { useProfileStore } from '~/stores/profileStore'
 import { useDataStore } from '~/stores/dataStore'
 import UIUtils from '~/utils/UIUtils'
 import { useToolbar } from '~/composables/useToolbar'
 import RouteConstants from '~/constants/RouteConstants'
 
-const appStore = useAppStore()
+const profileStore = useProfileStore()
 const dataStore = useDataStore()
 
 const areEmptyAccountsVisible = ref(false)
@@ -45,27 +45,27 @@ onMounted(() => {
 })
 
 const onSave = async () => {
-  appStore.dashboard.areEmptyAccountsVisible = areEmptyAccountsVisible.value
-  appStore.dashboard.showDecimal = showDecimal.value
+  profileStore.dashboard.areEmptyAccountsVisible = areEmptyAccountsVisible.value
+  profileStore.dashboard.showDecimal = showDecimal.value
 
-  appStore.dashboard.excludedAccountsList = excludedAccountsList.value
-  appStore.dashboard.excludedCategoriesList = excludedCategoriesList.value
-  appStore.dashboard.excludedTagsList = excludedTagsList.value
+  profileStore.dashboard.excludedAccountsList = excludedAccountsList.value
+  profileStore.dashboard.excludedCategoriesList = excludedCategoriesList.value
+  profileStore.dashboard.excludedTagsList = excludedTagsList.value
 
-  await appStore.writeProfile()
+  await profileStore.writeProfile()
 
   UIUtils.showToastSuccess('User preferences saved')
   init()
 }
 
 const init = () => {
-  areEmptyAccountsVisible.value = appStore.dashboard.areEmptyAccountsVisible
-  showDecimal.value = appStore.dashboard.showDecimal
+  areEmptyAccountsVisible.value = profileStore.dashboard.areEmptyAccountsVisible
+  showDecimal.value = profileStore.dashboard.showDecimal
 
 
-  excludedAccountsList.value = appStore.dashboard.excludedAccountsList
-  excludedCategoriesList.value = appStore.dashboard.excludedCategoriesList
-  excludedTagsList.value = appStore.dashboard.excludedTagsList
+  excludedAccountsList.value = profileStore.dashboard.excludedAccountsList
+  excludedCategoriesList.value = profileStore.dashboard.excludedCategoriesList
+  excludedTagsList.value = profileStore.dashboard.excludedTagsList
 }
 
 const toolbar = useToolbar()

--- a/front/pages/settings/user-preferences-date.vue
+++ b/front/pages/settings/user-preferences-date.vue
@@ -34,13 +34,13 @@
 
 <script setup>
 import { onMounted, ref } from 'vue'
-import { useAppStore } from '~/stores/appStore'
+import { useProfileStore } from '~/stores/profileStore'
 import { useDataStore } from '~/stores/dataStore'
 import UIUtils from '~/utils/UIUtils'
 import { useToolbar } from '~/composables/useToolbar'
 import RouteConstants from '~/constants/RouteConstants'
 
-const appStore = useAppStore()
+const profileStore = useProfileStore()
 const dataStore = useDataStore()
 
 // const isDateformatVisible = ref(false)
@@ -58,18 +58,18 @@ onMounted(() => {
 })
 
 const onSave = async () => {
-  appStore.dateFormat = dateFormat.value
-  appStore.dashboard.firstDayOfMonth = firstDayOfMonth.value
+  profileStore.dateFormat = dateFormat.value
+  profileStore.dashboard.firstDayOfMonth = firstDayOfMonth.value
 
-  await appStore.writeProfile()
+  await profileStore.writeProfile()
 
   UIUtils.showToastSuccess('User preferences saved')
   init()
 }
 
 const init = () => {
-  dateFormat.value = appStore.dateFormat
-  firstDayOfMonth.value = appStore.dashboard.firstDayOfMonth
+  dateFormat.value = profileStore.dateFormat
+  firstDayOfMonth.value = profileStore.dashboard.firstDayOfMonth
 }
 
 const toolbar = useToolbar()

--- a/front/pages/settings/user-preferences-new-transaction-defaults.vue
+++ b/front/pages/settings/user-preferences-new-transaction-defaults.vue
@@ -22,13 +22,13 @@
 
 <script setup>
 import { onMounted, ref } from 'vue'
-import { useAppStore } from '~/stores/appStore'
+import { useProfileStore } from '~/stores/profileStore'
 import { useDataStore } from '~/stores/dataStore'
 import UIUtils from '~/utils/UIUtils'
 import { useToolbar } from '~/composables/useToolbar'
 import RouteConstants from '~/constants/RouteConstants'
 
-const appStore = useAppStore()
+const profileStore = useProfileStore()
 const dataStore = useDataStore()
 
 const defaultAccountSource = ref(null)
@@ -42,24 +42,24 @@ onMounted(() => {
 })
 
 const onSave = async () => {
-  appStore.defaultAccountSource = defaultAccountSource.value
-  appStore.defaultAccountDestination = defaultAccountDestination.value
-  appStore.defaultCategory = defaultCategory.value
-  appStore.defaultTags = defaultTags.value
-  appStore.autoAddedTags = autoAddedTags.value
+  profileStore.defaultAccountSource = defaultAccountSource.value
+  profileStore.defaultAccountDestination = defaultAccountDestination.value
+  profileStore.defaultCategory = defaultCategory.value
+  profileStore.defaultTags = defaultTags.value
+  profileStore.autoAddedTags = autoAddedTags.value
 
-  await appStore.writeProfile()
+  await profileStore.writeProfile()
 
   UIUtils.showToastSuccess('User preferences saved')
   init()
 }
 
 const init = () => {
-  defaultAccountSource.value = appStore.defaultAccountSource
-  defaultAccountDestination.value = appStore.defaultAccountDestination
-  defaultCategory.value = appStore.defaultCategory
-  defaultTags.value = appStore.defaultTags
-  autoAddedTags.value = appStore.autoAddedTags
+  defaultAccountSource.value = profileStore.defaultAccountSource
+  defaultAccountDestination.value = profileStore.defaultAccountDestination
+  defaultCategory.value = profileStore.defaultCategory
+  defaultTags.value = profileStore.defaultTags
+  autoAddedTags.value = profileStore.autoAddedTags
 }
 
 const toolbar = useToolbar()

--- a/front/pages/settings/user-preferences-quick-transaction-amounts.vue
+++ b/front/pages/settings/user-preferences-quick-transaction-amounts.vue
@@ -23,13 +23,13 @@
 
 <script setup>
 import { onMounted, ref } from 'vue'
-import { useAppStore } from '~/stores/appStore'
+import { useProfileStore } from '~/stores/profileStore'
 import { useDataStore } from '~/stores/dataStore'
 import UIUtils from '~/utils/UIUtils'
 import { useToolbar } from '~/composables/useToolbar'
 import RouteConstants from '~/constants/RouteConstants'
 
-const appStore = useAppStore()
+const profileStore = useProfileStore()
 const dataStore = useDataStore()
 
 const quickAmountValues = ref([])
@@ -39,20 +39,20 @@ onMounted(() => {
 })
 
 const onSave = async () => {
-  appStore.quickValueButtons = quickAmountValues.value.map((item) => {
+  profileStore.quickValueButtons = quickAmountValues.value.map((item) => {
     let value = sanitizeAmount(item.value)
     let startsWithOperator = ['-', '+'].includes(value[0])
     return startsWithOperator ? value : `+${value}`
   })
 
-  await appStore.writeProfile()
+  await profileStore.writeProfile()
 
   UIUtils.showToastSuccess('User preferences saved')
   init()
 }
 
 const init = () => {
-  quickAmountValues.value = appStore.quickValueButtons.map((item) => {
+  quickAmountValues.value = profileStore.quickValueButtons.map((item) => {
     return { value: item }
   })
 }

--- a/front/pages/settings/user-preferences-transaction-fields-order.vue
+++ b/front/pages/settings/user-preferences-transaction-fields-order.vue
@@ -24,7 +24,7 @@
 
 <script setup>
 import { onMounted, ref } from 'vue'
-import { useAppStore } from '~/stores/appStore'
+import { useProfileStore } from '~/stores/profileStore'
 import { useDataStore } from '~/stores/dataStore'
 import UIUtils from '~/utils/UIUtils'
 import { useToolbar } from '~/composables/useToolbar'
@@ -32,7 +32,7 @@ import RouteConstants from '~/constants/RouteConstants'
 import { FORM_CONSTANTS_TRANSACTION_FIELDS_LIST } from '~/constants/FormConstants'
 import * as FormConstants from '~/constants/FormConstants'
 
-const appStore = useAppStore()
+const profileStore = useProfileStore()
 const dataStore = useDataStore()
 
 const fieldsList = ref([])
@@ -42,17 +42,17 @@ onMounted(() => {
 })
 
 const onSave = async () => {
-  appStore.transactionOrderedFieldsList = fieldsList.value
+  profileStore.transactionOrderedFieldsList = fieldsList.value
   
-  await appStore.writeProfile()
+  await profileStore.writeProfile()
 
   UIUtils.showToastSuccess('User preferences saved')
   init()
 }
 
 const init = () => {
-  let isListOk = appStore.transactionOrderedFieldsList.length === FORM_CONSTANTS_TRANSACTION_FIELDS_LIST.length
-  fieldsList.value = isListOk ? appStore.transactionOrderedFieldsList : FORM_CONSTANTS_TRANSACTION_FIELDS_LIST
+  let isListOk = profileStore.transactionOrderedFieldsList.length === FORM_CONSTANTS_TRANSACTION_FIELDS_LIST.length
+  fieldsList.value = isListOk ? profileStore.transactionOrderedFieldsList : FORM_CONSTANTS_TRANSACTION_FIELDS_LIST
 }
 
 const toolbar = useToolbar()

--- a/front/pages/settings/user-preferences-transactions.vue
+++ b/front/pages/settings/user-preferences-transactions.vue
@@ -48,14 +48,14 @@
 
 <script setup>
 import { onMounted, ref } from 'vue'
-import { useAppStore } from '~/stores/appStore'
+import { useProfileStore } from '~/stores/profileStore'
 import { useDataStore } from '~/stores/dataStore'
 import UIUtils from '~/utils/UIUtils'
 import { useToolbar } from '~/composables/useToolbar'
 import RouteConstants from '~/constants/RouteConstants'
 import { HERO_ICONS_LIST } from '~/constants/TransactionConstants.js'
 
-const appStore = useAppStore()
+const profileStore = useProfileStore()
 
 const heroIcons = ref([])
 const heroIconsList = HERO_ICONS_LIST
@@ -77,39 +77,39 @@ onMounted(() => {
 })
 
 const onSave = async () => {
-  appStore.heroIcons = heroIcons.value
-  appStore.copyCategoryToDescription = copyCategoryToDescription.value
-  appStore.copyTagToDescription = copyTagToDescription.value
-  appStore.copyTagToCategory = copyTagToCategory.value
-  appStore.defaultAccountSource = defaultAccountSource.value
-  appStore.defaultAccountDestination = defaultAccountDestination.value
-  appStore.defaultCategory = defaultCategory.value
-  appStore.defaultTags = defaultTags.value
-  appStore.autoAddedTags = autoAddedTags.value
-  appStore.quickValueButtons = quickAmountValues.value.map((item) => {
+  profileStore.heroIcons = heroIcons.value
+  profileStore.copyCategoryToDescription = copyCategoryToDescription.value
+  profileStore.copyTagToDescription = copyTagToDescription.value
+  profileStore.copyTagToCategory = copyTagToCategory.value
+  profileStore.defaultAccountSource = defaultAccountSource.value
+  profileStore.defaultAccountDestination = defaultAccountDestination.value
+  profileStore.defaultCategory = defaultCategory.value
+  profileStore.defaultTags = defaultTags.value
+  profileStore.autoAddedTags = autoAddedTags.value
+  profileStore.quickValueButtons = quickAmountValues.value.map((item) => {
     let value = sanitizeAmount(item.value)
     let startsWithOperator = ['-', '+'].includes(value[0])
     return startsWithOperator ? value : `+${value}`
   })
 
-  await appStore.writeProfile()
+  await profileStore.writeProfile()
 
   UIUtils.showToastSuccess('User preferences saved')
   init()
 }
 
 const init = () => {
-  heroIcons.value = appStore.heroIcons
-  copyCategoryToDescription.value = appStore.copyCategoryToDescription
-  copyTagToDescription.value = appStore.copyTagToDescription
-  copyTagToCategory.value = appStore.copyTagToCategory
+  heroIcons.value = profileStore.heroIcons
+  copyCategoryToDescription.value = profileStore.copyCategoryToDescription
+  copyTagToDescription.value = profileStore.copyTagToDescription
+  copyTagToCategory.value = profileStore.copyTagToCategory
 
-  defaultAccountSource.value = appStore.defaultAccountSource
-  defaultAccountDestination.value = appStore.defaultAccountDestination
-  defaultCategory.value = appStore.defaultCategory
-  defaultTags.value = appStore.defaultTags
-  autoAddedTags.value = appStore.autoAddedTags
-  quickAmountValues.value = appStore.quickValueButtons.map((item) => {
+  defaultAccountSource.value = profileStore.defaultAccountSource
+  defaultAccountDestination.value = profileStore.defaultAccountDestination
+  defaultCategory.value = profileStore.defaultCategory
+  defaultTags.value = profileStore.defaultTags
+  autoAddedTags.value = profileStore.autoAddedTags
+  quickAmountValues.value = profileStore.quickValueButtons.map((item) => {
     return { value: item }
   })
 }

--- a/front/pages/settings/user-preferences-ui.vue
+++ b/front/pages/settings/user-preferences-ui.vue
@@ -40,7 +40,7 @@
 
 <script setup>
 import { onMounted, ref } from 'vue'
-import { useAppStore } from '~/stores/appStore'
+import { useProfileStore } from '~/stores/profileStore'
 import { useDataStore } from '~/stores/dataStore'
 import UIUtils from '~/utils/UIUtils'
 import { useToolbar } from '~/composables/useToolbar'
@@ -48,7 +48,7 @@ import RouteConstants from '~/constants/RouteConstants'
 import { NUMBER_FORMAT } from '~/utils/MathUtils.js'
 import TablerIconConstants from '~/constants/TablerIconConstants.js'
 
-const appStore = useAppStore()
+const profileStore = useProfileStore()
 const dataStore = useDataStore()
 
 const numberFormat = ref(null)
@@ -67,30 +67,30 @@ onMounted(() => {
 })
 
 const onSave = async () => {
-  appStore.numberFormat = numberFormat.value
+  profileStore.numberFormat = numberFormat.value
 
-  appStore.lowerCaseTransactionDescription = lowerCaseTransactionDescription.value
-  appStore.lowerCaseAccountName = lowerCaseAccountName.value
-  appStore.lowerCaseCategoryName = lowerCaseCategoryName.value
-  appStore.lowerCaseTagName = lowerCaseTagName.value
+  profileStore.lowerCaseTransactionDescription = lowerCaseTransactionDescription.value
+  profileStore.lowerCaseAccountName = lowerCaseAccountName.value
+  profileStore.lowerCaseCategoryName = lowerCaseCategoryName.value
+  profileStore.lowerCaseTagName = lowerCaseTagName.value
 
-  appStore.darkTheme = darkTheme.value
+  profileStore.darkTheme = darkTheme.value
 
-  await appStore.writeProfile()
+  await profileStore.writeProfile()
 
   UIUtils.showToastSuccess('User preferences saved')
   init()
 }
 
 const init = () => {
-  numberFormat.value = appStore.numberFormat
+  numberFormat.value = profileStore.numberFormat
 
-  lowerCaseTransactionDescription.value = appStore.lowerCaseTransactionDescription
-  lowerCaseAccountName.value = appStore.lowerCaseAccountName
-  lowerCaseCategoryName.value = appStore.lowerCaseCategoryName
-  lowerCaseTagName.value = appStore.lowerCaseTagName
+  lowerCaseTransactionDescription.value = profileStore.lowerCaseTransactionDescription
+  lowerCaseAccountName.value = profileStore.lowerCaseAccountName
+  lowerCaseCategoryName.value = profileStore.lowerCaseCategoryName
+  lowerCaseTagName.value = profileStore.lowerCaseTagName
 
-  darkTheme.value = appStore.darkTheme
+  darkTheme.value = profileStore.darkTheme
 }
 
 const toolbar = useToolbar()

--- a/front/pages/tags/[[id]].vue
+++ b/front/pages/tags/[[id]].vue
@@ -61,7 +61,7 @@ import { ref } from 'vue';
 import RouteConstants from '~/constants/RouteConstants'
 import { useDataStore } from '~/stores/dataStore'
 import _, { cloneDeep, get, set } from 'lodash'
-import { useAppStore } from '~/stores/appStore'
+import { useProfileStore } from '~/stores/profileStore'
 import { ref } from 'vue'
 import { useForm } from '~/composables/useForm'
 import { generateChildren } from '~/utils/VueUtils'
@@ -72,7 +72,7 @@ import TagSelect from '~/components/select/tag-select.vue'
 import { TUTORIAL_CONSTANTS } from '~/constants/TutorialConstants.js'
 
 let dataStore = useDataStore()
-let appStore = useAppStore()
+let profileStore = useProfileStore()
 const route = useRoute()
 
 const form = ref(null)
@@ -136,7 +136,7 @@ const onRefresh = () => {
 }
 
 watch(tag, (newValue) => {
-  if (!appStore.lowerCaseTagName) {
+  if (!profileStore.lowerCaseTagName) {
     return
   }
   tag.value = newValue.toLowerCase()

--- a/front/pages/transaction-templates/[[id]].vue
+++ b/front/pages/transaction-templates/[[id]].vue
@@ -56,7 +56,7 @@ import { ref } from 'vue';
 import RouteConstants from '~/constants/RouteConstants'
 import { useDataStore } from '~/stores/dataStore'
 import _, { get } from 'lodash'
-import { useAppStore } from '~/stores/appStore'
+import { useProfileStore } from '~/stores/profileStore'
 import { ref } from 'vue'
 import { useForm } from '~/composables/useForm'
 import Account from '~/models/Account'
@@ -73,7 +73,7 @@ const refAmount = ref(null)
 // ------------------------------------
 
 let dataStore = useDataStore()
-let appStore = useAppStore()
+let profileStore = useProfileStore()
 const route = useRoute()
 
 const form = ref(null)

--- a/front/pages/transactions/[[id]].vue
+++ b/front/pages/transactions/[[id]].vue
@@ -122,7 +122,7 @@ import { ref } from 'vue';
 import RouteConstants from '~/constants/RouteConstants'
 import { useDataStore } from '~/stores/dataStore'
 import _, { get, head, isEqual } from 'lodash'
-import { useAppStore } from '~/stores/appStore'
+import { useProfileStore } from '~/stores/profileStore'
 import { ref } from 'vue'
 import { useForm } from '~/composables/useForm'
 import Account from '~/models/Account'
@@ -144,7 +144,7 @@ const refAmount = ref(null)
 // ------------------------------------
 
 let dataStore = useDataStore()
-let appStore = useAppStore()
+let profileStore = useProfileStore()
 const route = useRoute()
 
 const form = ref(null)
@@ -236,7 +236,7 @@ const onTransactionTemplateSelected = (transactionTemplate) => {
 }
 
 watch(category, async (newValue) => {
-  if (!appStore.copyCategoryToDescription || !isStringEmpty(description.value) || itemId.value || !newValue) {
+  if (!profileStore.copyCategoryToDescription || !isStringEmpty(description.value) || itemId.value || !newValue) {
     return
   }
   description.value = Category.getDisplayName(newValue)
@@ -250,12 +250,12 @@ watch(tags, async (newValue) => {
   // Give child tags more priority for more granularity
   const sortedTagNames = sortByPath(newValue, 'level', false).map((tag) => Tag.getDisplayNameEllipsized(tag).toLowerCase())
 
-  if (appStore.copyTagToDescription && isStringEmpty(description.value)) {
+  if (profileStore.copyTagToDescription && isStringEmpty(description.value)) {
     // The first one is the one with the highest level
     description.value = head(sortedTagNames)
   }
 
-  if (appStore.copyTagToCategory && !category.value) {
+  if (profileStore.copyTagToCategory && !category.value) {
     for (let tagName of sortedTagNames) {
       let foundCategory = dataStore.categoryList.find((category) => {
         let categoryName = Category.getDisplayName(category).toLowerCase()
@@ -305,7 +305,7 @@ const isTypeTransfer = computed(() => isEqual(type.value, Transaction.types.tran
 
 const getStyleForField = (fieldCode) => {
   if (isTypeExpense.value) {
-    let position = appStore.transactionOrderedFieldsList.findIndex((item) => item.code === fieldCode)
+    let position = profileStore.transactionOrderedFieldsList.findIndex((item) => item.code === fieldCode)
     return `order: ${position}`
   }
 
@@ -313,12 +313,12 @@ const getStyleForField = (fieldCode) => {
 
   // Should be same as income, but reverse the position on source with destination
   if (isTypeIncome.value) {
-    let position = appStore.transactionOrderedFieldsList.findIndex((item) => item.code === fieldCode)
+    let position = profileStore.transactionOrderedFieldsList.findIndex((item) => item.code === fieldCode)
     if (fieldCode === FORM_CONSTANTS_TRANSACTION_FIELDS.TRANSACTION_FORM_FIELD_SOURCE_ACCOUNT) {
-      position = appStore.transactionOrderedFieldsList.findIndex((item) => item.code === FORM_CONSTANTS_TRANSACTION_FIELDS.TRANSACTION_FORM_FIELD_DESTINATION_ACCOUNT)
+      position = profileStore.transactionOrderedFieldsList.findIndex((item) => item.code === FORM_CONSTANTS_TRANSACTION_FIELDS.TRANSACTION_FORM_FIELD_DESTINATION_ACCOUNT)
     }
     if (fieldCode === FORM_CONSTANTS_TRANSACTION_FIELDS.TRANSACTION_FORM_FIELD_DESTINATION_ACCOUNT) {
-      position = appStore.transactionOrderedFieldsList.findIndex((item) => item.code === FORM_CONSTANTS_TRANSACTION_FIELDS.TRANSACTION_FORM_FIELD_SOURCE_ACCOUNT)
+      position = profileStore.transactionOrderedFieldsList.findIndex((item) => item.code === FORM_CONSTANTS_TRANSACTION_FIELDS.TRANSACTION_FORM_FIELD_SOURCE_ACCOUNT)
     }
     return `order: ${position}`
   }
@@ -328,7 +328,7 @@ const getStyleForField = (fieldCode) => {
     if (fieldTypeAccountsList.includes(fieldCode)) {
       return `order: 0`
     }
-    let position = appStore.transactionOrderedFieldsList.findIndex((item) => item.code === fieldCode)
+    let position = profileStore.transactionOrderedFieldsList.findIndex((item) => item.code === fieldCode)
     return `order: ${position}`
   }
 
@@ -366,13 +366,13 @@ watch(type, (newValue, oldValue) => {
 })
 
 watch(description, (newValue) => {
-  if (!appStore.lowerCaseTransactionDescription) {
+  if (!profileStore.lowerCaseTransactionDescription) {
     return
   }
   description.value = newValue.toLowerCase()
 })
 
-const showSourceAccountSuggestion = computed(() => !appStore.defaultAccountSource && !accountSource.value)
+const showSourceAccountSuggestion = computed(() => !profileStore.defaultAccountSource && !accountSource.value)
 
 const toolbar = useToolbar()
 toolbar.init({

--- a/front/plugins/axios.js
+++ b/front/plugins/axios.js
@@ -4,12 +4,12 @@ import { get } from 'lodash'
 
 axios.interceptors.request.use(
   (config) => {
-    const profileStore = useProfileStore()
+    const appStore = useAppStore()
 
     const controller = new AbortController()
 
-    let authToken = profileStore.authToken
-    if (!profileStore.hasAuthToken) {
+    let authToken = appStore.authToken
+    if (!appStore.hasAuthToken) {
       const router = useRouter()
       UIUtils.showToastError('No personal access token...')
       // router.push(RouteConstants.ROUTE_SETTINGS_APP_CONFIG).then(r => {})
@@ -17,7 +17,7 @@ axios.interceptors.request.use(
     }
 
     config.headers['Authorization'] = `Bearer ${authToken}`
-    config.timeout = profileStore.queryTimeout
+    config.timeout = appStore.queryTimeout
     return config
   },
   (error) => {

--- a/front/plugins/axios.js
+++ b/front/plugins/axios.js
@@ -1,15 +1,15 @@
 import axios from 'axios'
-import { useAppStore } from '~/stores/appStore'
+import { useProfileStore } from '~/stores/profileStore'
 import { get } from 'lodash'
 
 axios.interceptors.request.use(
   (config) => {
-    const appStore = useAppStore()
+    const profileStore = useProfileStore()
 
     const controller = new AbortController()
 
-    let authToken = appStore.authToken
-    if (!appStore.hasAuthToken) {
+    let authToken = profileStore.authToken
+    if (!profileStore.hasAuthToken) {
       const router = useRouter()
       UIUtils.showToastError('No personal access token...')
       // router.push(RouteConstants.ROUTE_SETTINGS_APP_CONFIG).then(r => {})
@@ -17,7 +17,7 @@ axios.interceptors.request.use(
     }
 
     config.headers['Authorization'] = `Bearer ${authToken}`
-    config.timeout = appStore.queryTimeout
+    config.timeout = profileStore.queryTimeout
     return config
   },
   (error) => {

--- a/front/repository/AccountRepository.js
+++ b/front/repository/AccountRepository.js
@@ -2,7 +2,7 @@ import BaseRepository from '~/repository/BaseRepository'
 import { faker } from '@faker-js/faker'
 import axios from 'axios'
 import _ from 'lodash'
-import { useAppStore } from '~/stores/appStore'
+import { useProfileStore } from '~/stores/profileStore'
 import { useDataStore } from '~/stores/dataStore'
 
 class AccountRepository extends BaseRepository {

--- a/front/repository/BaseRepository.js
+++ b/front/repository/BaseRepository.js
@@ -8,10 +8,10 @@ class BaseRepository {
   }
 
   getUrl() {
-    const profileStore = useProfileStore()
+    const appStore = useAppStore()
     // let appURL = window.location.host
     // let appURL = 'http://127.0.0.1:8000'
-    return `${profileStore.picoBackendURL}/${this.endpoint}`
+    return `${appStore.picoBackendURL}/${this.endpoint}`
   }
 
   async getOne(id) {

--- a/front/repository/BaseRepository.js
+++ b/front/repository/BaseRepository.js
@@ -9,8 +9,6 @@ class BaseRepository {
 
   getUrl() {
     const appStore = useAppStore()
-    // let appURL = window.location.host
-    // let appURL = 'http://127.0.0.1:8000'
     return `${appStore.picoBackendURL}/${this.endpoint}`
   }
 

--- a/front/repository/BaseRepository.js
+++ b/front/repository/BaseRepository.js
@@ -8,10 +8,10 @@ class BaseRepository {
   }
 
   getUrl() {
-    const appStore = useAppStore()
+    const profileStore = useProfileStore()
     // let appURL = window.location.host
     // let appURL = 'http://127.0.0.1:8000'
-    return `${appStore.picoBackendURL}/${this.endpoint}`
+    return `${profileStore.picoBackendURL}/${this.endpoint}`
   }
 
   async getOne(id) {

--- a/front/repository/CurrencyRepository.js
+++ b/front/repository/CurrencyRepository.js
@@ -8,7 +8,7 @@ class CurrencyRepository extends BaseRepository {
   }
 
   async getCurrencyExchange() {
-    const profileStore = useProfileStore()
+    const appStore = useAppStore()
     const url = `${appStore.picoBackendURL}/api/currencies/exchange`
     let response = await axios.get(url)
     return _.get(response, 'data', {})

--- a/front/repository/CurrencyRepository.js
+++ b/front/repository/CurrencyRepository.js
@@ -8,8 +8,8 @@ class CurrencyRepository extends BaseRepository {
   }
 
   async getCurrencyExchange() {
-    const appStore = useAppStore()
-    const url = `${appStore.picoBackendURL}/api/currencies/exchange`
+    const profileStore = useProfileStore()
+    const url = `${profileStore.picoBackendURL}/api/currencies/exchange`
     let response = await axios.get(url)
     return _.get(response, 'data', {})
   }

--- a/front/repository/CurrencyRepository.js
+++ b/front/repository/CurrencyRepository.js
@@ -9,7 +9,7 @@ class CurrencyRepository extends BaseRepository {
 
   async getCurrencyExchange() {
     const profileStore = useProfileStore()
-    const url = `${profileStore.picoBackendURL}/api/currencies/exchange`
+    const url = `${appStore.picoBackendURL}/api/currencies/exchange`
     let response = await axios.get(url)
     return _.get(response, 'data', {})
   }

--- a/front/repository/TransactionRepository.js
+++ b/front/repository/TransactionRepository.js
@@ -10,7 +10,7 @@ class TransactionRepository extends BaseRepository {
 
 
   async searchTransaction({ filters = [], page = 1, pageSize = 50 } = {}) {
-    const profileStore = useProfileStore()
+    const appStore = useAppStore()
     const url = `${appStore.picoBackendURL}/api/search/transactions`
     let searchUrl = this.getUrlForRequest({ filters, page, pageSize, url })
     let response = await axios.get(searchUrl)

--- a/front/repository/TransactionRepository.js
+++ b/front/repository/TransactionRepository.js
@@ -10,8 +10,8 @@ class TransactionRepository extends BaseRepository {
 
 
   async searchTransaction({ filters = [], page = 1, pageSize = 50 } = {}) {
-    const appStore = useAppStore()
-    const url = `${appStore.picoBackendURL}/api/search/transactions`
+    const profileStore = useProfileStore()
+    const url = `${profileStore.picoBackendURL}/api/search/transactions`
     let searchUrl = this.getUrlForRequest({ filters, page, pageSize, url })
     let response = await axios.get(searchUrl)
     return _.get(response, 'data', {})

--- a/front/repository/TransactionRepository.js
+++ b/front/repository/TransactionRepository.js
@@ -11,7 +11,7 @@ class TransactionRepository extends BaseRepository {
 
   async searchTransaction({ filters = [], page = 1, pageSize = 50 } = {}) {
     const profileStore = useProfileStore()
-    const url = `${profileStore.picoBackendURL}/api/search/transactions`
+    const url = `${appStore.picoBackendURL}/api/search/transactions`
     let searchUrl = this.getUrlForRequest({ filters, page, pageSize, url })
     let response = await axios.get(searchUrl)
     return _.get(response, 'data', {})

--- a/front/stores/appStore.js
+++ b/front/stores/appStore.js
@@ -12,7 +12,6 @@ import { NUMBER_FORMAT } from '~/utils/MathUtils.js'
 import ProfileRepository from '~/repository/ProfileRepository'
 import ProfileTransformer from '~/transformers/ProfileTransformer'
 
-
 export const useAppStore = defineStore('app', {
   state: () => {
     const defaultUrl = window.location.origin
@@ -21,6 +20,7 @@ export const useAppStore = defineStore('app', {
     return {
       authToken: useLocalStorage('authToken', ''),
       picoBackendURL: useLocalStorage('picoBackendURL', defaultUrl),
+      syncProfileInDB: useLocalStorage('syncProfileInDB', true),
 
       currentAppVersion: runtimeConfig.public.version,
       queryTimeout: runtimeConfig.public.queryTimeout,
@@ -47,6 +47,6 @@ export const useAppStore = defineStore('app', {
         return
       }
       this.latestAppVersion = get(response, 'data')
-    }
+    },
   },
 })

--- a/front/stores/appStore.js
+++ b/front/stores/appStore.js
@@ -12,31 +12,6 @@ import { NUMBER_FORMAT } from '~/utils/MathUtils.js'
 import ProfileRepository from '~/repository/ProfileRepository'
 import ProfileTransformer from '~/transformers/ProfileTransformer'
 
-const PERSISTED_FIELDS = new Set([
-  'darkTheme',
-  'voiceLanguage',
-  'autoAddTransactionFromVoice',
-  'defaultAccountSource',
-  'defaultAccountDestination',
-  'defaultCategory',
-  'defaultTags',
-  'autoAddedTags',
-  'quickValueButtons',
-  'transactionOrderedFieldsList',
-  'dateFormat',
-  'copyCategoryToDescription',
-  'copyTagToDescription',
-  'copyTagToCategory',
-  'showTagSelectAsGrid',
-  'numberFormat',
-  'lowerCaseTransactionDescription',
-  'lowerCaseAccountName',
-  'lowerCaseCategoryName',
-  'lowerCaseTagName',
-  'dashboard',
-])
-
-const NESTED_FIELDS = new Set(['dashboard'])
 
 export const useAppStore = defineStore('app', {
   state: () => {
@@ -44,57 +19,12 @@ export const useAppStore = defineStore('app', {
     const runtimeConfig = useRuntimeConfig()
 
     return {
-      isLoading: false,
+      authToken: useLocalStorage('authToken', ''),
+      picoBackendURL: useLocalStorage('picoBackendURL', defaultUrl),
 
       currentAppVersion: runtimeConfig.public.version,
       queryTimeout: runtimeConfig.public.queryTimeout,
       latestAppVersion: null,
-
-      darkTheme: useLocalStorage('darkTheme', false),
-      authToken: useLocalStorage('authToken', ''),
-      picoBackendURL: useLocalStorage('picoBackendURL', defaultUrl),
-
-      voiceLanguage: useLocalStorage('voiceLanguage', LanguageConstants.OPTION_ROMANIAN, { serializer: StorageSerializers.object }),
-      autoAddTransactionFromVoice: useLocalStorage('autoAddTransactionFromVoice', false),
-
-      defaultAccountSource: useLocalStorage('defaultAccountSource', null, { serializer: StorageSerializers.object }),
-      defaultAccountDestination: useLocalStorage('defaultAccountDestination', null, { serializer: StorageSerializers.object }),
-      defaultCategory: useLocalStorage('defaultCategory', null, { serializer: StorageSerializers.object }),
-
-      defaultTags: useLocalStorage('defaultTags', [], { serializer: StorageSerializers.object }),
-      autoAddedTags: useLocalStorage('autoAddedTags', [], { serializer: StorageSerializers.object }),
-
-      quickValueButtons: useLocalStorage('quickValueButtons', ['-10', '-1', '+1', '+10']),
-      transactionOrderedFieldsList: useLocalStorage('transactionOrderedFieldsList', FORM_CONSTANTS_TRANSACTION_FIELDS_LIST),
-
-      dateFormat: useLocalStorage('dateFormat', DateUtils.FORMAT_ENGLISH_DATE),
-
-      copyCategoryToDescription: useLocalStorage('copyCategoryToDescription', false),
-      copyTagToDescription: useLocalStorage('copyTagToDescription', true),
-      copyTagToCategory: useLocalStorage('copyTagToCategory', true),
-
-      showTagSelectAsGrid: useLocalStorage('showTagSelectAsGrid', true),
-
-      numberFormat: useLocalStorage('numberFormat', NUMBER_FORMAT.eu),
-      lowerCaseTransactionDescription: useLocalStorage('lowerCaseTransactionDescription', false),
-      lowerCaseAccountName: useLocalStorage('lowerCaseAccountName', false),
-      lowerCaseCategoryName: useLocalStorage('lowerCaseCategoryName', true),
-      lowerCaseTagName: useLocalStorage('lowerCaseTagName', true),
-
-      heroIcons: useLocalStorage(
-        'heroIcons',
-        HERO_ICONS_LIST.filter((item) => [HERO_ICONS.tag, HERO_ICONS.account].includes(item.code)),
-      ),
-
-      dashboard: {
-        firstDayOfMonth: useLocalStorage('firstDayOfMonth', 1),
-        showAccountAmounts: useLocalStorage('showAccountAmounts', true),
-        showDecimal: useLocalStorage('showDecimals', false),
-        areEmptyAccountsVisible: useLocalStorage('areEmptyAccountsVisible', false),
-        excludedAccountsList: useLocalStorage('excludedAccountsList', []),
-        excludedCategoriesList: useLocalStorage('excludedCategoriesList', []),
-        excludedTagsList: useLocalStorage('excludedTagsList', []),
-      },
     }
   },
 
@@ -111,60 +41,12 @@ export const useAppStore = defineStore('app', {
   },
 
   actions: {
-    async syncEverything() {
-      if (!this.hasAuthToken) {
-        return
-      }
-      const async1 = this.fetchLatestAppVersion()
-      const async2 = this.fetchProfile()
-      await Promise.all([async1, async2])
-      this.lastSync = new Date()
-    },
-
-    async fetchProfile() {
-      const response = await new ProfileRepository().getProfile()
-
-      if (response.data == null) {
-        return
-      }
-
-      const newValues = ProfileTransformer.transformFromApi(response.data)
-
-      for (let key of PERSISTED_FIELDS.values()) {
-        if (!(key in newValues)) {
-          continue
-        }
-        if (NESTED_FIELDS.has(key)) {
-          for (let nestedKey of Object.keys(newValues[key])) {
-            this.$state[key][nestedKey] = newValues[key][nestedKey]
-          }
-        } else {
-          this.$state[key] = newValues[key]
-        }
-      }
-    },
-
     async fetchLatestAppVersion() {
       let response = await new InfoRepository().getLatestVersion()
       if (!ResponseUtils.isSuccess(response)) {
         return
       }
       this.latestAppVersion = get(response, 'data')
-    },
-
-    async writeProfile() {
-      const data = {}
-      for (let key of PERSISTED_FIELDS.values()) {
-        if (NESTED_FIELDS.has(key)) {
-          data[key] = {}
-          for (let nestedKey of Object.keys(this.$state[key])) {
-            data[key][nestedKey] = this.$state[key][nestedKey]
-          }
-        } else {
-          data[key] = this.$state[key]
-        }
-      }
-      await new ProfileRepository().writeProfile(ProfileTransformer.transformToApi(data))
-    },
+    }
   },
 })

--- a/front/stores/dataStore.js
+++ b/front/stores/dataStore.js
@@ -8,7 +8,7 @@ import TagRepository from '~/repository/TagRepository'
 import AccountTransformer from '~/transformers/AccountTransformer'
 import TransactionTemplateRepository from '~/repository/TransactionTemplateRepository'
 import CurrencyRepository from '~/repository/CurrencyRepository'
-import { useAppStore } from '~/stores/appStore'
+import { useProfileStore } from '~/stores/profileStore'
 import { addMonths, differenceInHours, startOfDay, startOfMonth, subDays, subMonths, subYears } from 'date-fns'
 import CategoryTransformer from '~/transformers/CategoryTransformer'
 import TagTransformer from '~/transformers/TagTransformer'
@@ -68,12 +68,12 @@ export const useDataStore = defineStore('data', {
 
   getters: {
     dashboardAccounts(state) {
-      const appStore = useAppStore()
+      const profileStore = useProfileStore()
       return state.accountList.filter((account) => {
         return isEqual(Account.getType(account), Account.types.asset) &&
           Account.getIsActive(account) &&
           Account.getIsIncludedInNetWorth(account) &&
-          (Account.getBalance(account) != 0 || appStore.dashboard.areEmptyAccountsVisible)
+          (Account.getBalance(account) != 0 || profileStore.dashboard.areEmptyAccountsVisible)
       })
     },
 
@@ -127,8 +127,8 @@ export const useDataStore = defineStore('data', {
     },
 
     dashboardDateStart(state) {
-      const appStore = useAppStore()
-      let dateCurrentMonth = startOfDay(state.dashboard.month).setDate(appStore.dashboard.firstDayOfMonth)
+      const profileStore = useProfileStore()
+      let dateCurrentMonth = startOfDay(state.dashboard.month).setDate(profileStore.dashboard.firstDayOfMonth)
       return dateCurrentMonth > new Date() ? subMonths(dateCurrentMonth, 1) : dateCurrentMonth
     },
 
@@ -333,8 +333,8 @@ export const useDataStore = defineStore('data', {
     // },
 
     async syncEverything() {
-      const appStore = useAppStore()
-      if (!appStore.hasAuthToken) {
+      const profileStore = useProfileStore()
+      if (!profileStore.hasAuthToken) {
         return
       }
       let async1 = this.fetchCategories()

--- a/front/stores/profileStore.js
+++ b/front/stores/profileStore.js
@@ -6,19 +6,15 @@ import { FORM_CONSTANTS_TRANSACTION_FIELDS_LIST } from '~/constants/FormConstant
 import ResponseUtils from '~/utils/ResponseUtils'
 import { compareVersionStrings } from '~/utils/DataUtils'
 import InfoRepository from '~/repository/InfoRepository.js'
-import { get } from 'lodash'
+import { cloneDeep, get, omit } from 'lodash'
 import { HERO_ICONS, HERO_ICONS_LIST } from '~/constants/TransactionConstants.js'
 import { NUMBER_FORMAT } from '~/utils/MathUtils.js'
 import ProfileRepository from '~/repository/ProfileRepository'
 import ProfileTransformer from '~/transformers/ProfileTransformer'
 import { useAppStore } from '~/stores/appStore.js'
 
-
 export const useProfileStore = defineStore('profile', {
   state: () => {
-    const defaultUrl = window.location.origin
-    const runtimeConfig = useRuntimeConfig()
-
     return {
       isLoading: false,
 
@@ -65,13 +61,11 @@ export const useProfileStore = defineStore('profile', {
     }
   },
 
-  getters: {
-
-  },
+  getters: {},
 
   actions: {
-
     async fetchProfile() {
+      console.log('fetch profile')
       const response = await new ProfileRepository().getProfile()
 
       if (response.data == null) {
@@ -79,33 +73,15 @@ export const useProfileStore = defineStore('profile', {
       }
 
       const newValues = ProfileTransformer.transformFromApi(response.data)
+      console.log('newValues', newValues)
+      this.$patch(newValues)
 
-      // for (let key of PERSISTED_FIELDS.values()) {
-      //   if (!(key in newValues)) {
-      //     continue
-      //   }
-      //   if (NESTED_FIELDS.has(key)) {
-      //     for (let nestedKey of Object.keys(newValues[key])) {
-      //       this.$state[key][nestedKey] = newValues[key][nestedKey]
-      //     }
-      //   } else {
-      //     this.$state[key] = newValues[key]
-      //   }
-      // }
     },
 
     async writeProfile() {
-      const data = {}
-      // for (let key of PERSISTED_FIELDS.values()) {
-      //   if (NESTED_FIELDS.has(key)) {
-      //     data[key] = {}
-      //     for (let nestedKey of Object.keys(this.$state[key])) {
-      //       data[key][nestedKey] = this.$state[key][nestedKey]
-      //     }
-      //   } else {
-      //     data[key] = this.$state[key]
-      //   }
-      // }
+      let data = cloneDeep(this.$state)
+      data = omit(data, 'dashboard.showAccountAmounts')
+
       await new ProfileRepository().writeProfile(ProfileTransformer.transformToApi(data))
     },
   },

--- a/front/stores/profileStore.js
+++ b/front/stores/profileStore.js
@@ -65,24 +65,29 @@ export const useProfileStore = defineStore('profile', {
 
   actions: {
     async fetchProfile() {
-      console.log('fetch profile')
-      const response = await new ProfileRepository().getProfile()
-
-      if (response.data == null) {
+      const appStore = useAppStore()
+      if (!appStore.syncProfileInDB) {
         return
       }
-
-      const newValues = ProfileTransformer.transformFromApi(response.data)
-      console.log('newValues', newValues)
-      this.$patch(newValues)
-
+      this.isLoading = true
+      const response = await new ProfileRepository().getProfile()
+      let responseData = response.data ?? {}
+      responseData = ProfileTransformer.transformFromApi(responseData)
+      this.$patch(responseData)
+      this.isLoading = false
     },
 
     async writeProfile() {
+      const appStore = useAppStore()
+      if (!appStore.syncProfileInDB) {
+        return
+      }
+
+      this.isLoading = true
       let data = cloneDeep(this.$state)
       data = omit(data, 'dashboard.showAccountAmounts')
-
       await new ProfileRepository().writeProfile(ProfileTransformer.transformToApi(data))
+      this.isLoading = false
     },
   },
 })

--- a/front/stores/profileStore.js
+++ b/front/stores/profileStore.js
@@ -1,0 +1,112 @@
+import { defineStore } from 'pinia'
+import { StorageSerializers, useLocalStorage } from '@vueuse/core'
+import * as LanguageConstants from '~/constants/LanguageConstants'
+import DateUtils from '~/utils/DateUtils'
+import { FORM_CONSTANTS_TRANSACTION_FIELDS_LIST } from '~/constants/FormConstants'
+import ResponseUtils from '~/utils/ResponseUtils'
+import { compareVersionStrings } from '~/utils/DataUtils'
+import InfoRepository from '~/repository/InfoRepository.js'
+import { get } from 'lodash'
+import { HERO_ICONS, HERO_ICONS_LIST } from '~/constants/TransactionConstants.js'
+import { NUMBER_FORMAT } from '~/utils/MathUtils.js'
+import ProfileRepository from '~/repository/ProfileRepository'
+import ProfileTransformer from '~/transformers/ProfileTransformer'
+import { useAppStore } from '~/stores/appStore.js'
+
+
+export const useProfileStore = defineStore('profile', {
+  state: () => {
+    const defaultUrl = window.location.origin
+    const runtimeConfig = useRuntimeConfig()
+
+    return {
+      isLoading: false,
+
+      darkTheme: useLocalStorage('darkTheme', false),
+
+      defaultAccountSource: useLocalStorage('defaultAccountSource', null, { serializer: StorageSerializers.object }),
+      defaultAccountDestination: useLocalStorage('defaultAccountDestination', null, { serializer: StorageSerializers.object }),
+      defaultCategory: useLocalStorage('defaultCategory', null, { serializer: StorageSerializers.object }),
+
+      defaultTags: useLocalStorage('defaultTags', [], { serializer: StorageSerializers.object }),
+      autoAddedTags: useLocalStorage('autoAddedTags', [], { serializer: StorageSerializers.object }),
+
+      quickValueButtons: useLocalStorage('quickValueButtons', ['-10', '-1', '+1', '+10']),
+      transactionOrderedFieldsList: useLocalStorage('transactionOrderedFieldsList', FORM_CONSTANTS_TRANSACTION_FIELDS_LIST),
+
+      dateFormat: useLocalStorage('dateFormat', DateUtils.FORMAT_ENGLISH_DATE),
+
+      copyCategoryToDescription: useLocalStorage('copyCategoryToDescription', false),
+      copyTagToDescription: useLocalStorage('copyTagToDescription', true),
+      copyTagToCategory: useLocalStorage('copyTagToCategory', true),
+
+      showTagSelectAsGrid: useLocalStorage('showTagSelectAsGrid', true),
+
+      numberFormat: useLocalStorage('numberFormat', NUMBER_FORMAT.eu),
+      lowerCaseTransactionDescription: useLocalStorage('lowerCaseTransactionDescription', false),
+      lowerCaseAccountName: useLocalStorage('lowerCaseAccountName', false),
+      lowerCaseCategoryName: useLocalStorage('lowerCaseCategoryName', true),
+      lowerCaseTagName: useLocalStorage('lowerCaseTagName', true),
+
+      heroIcons: useLocalStorage(
+        'heroIcons',
+        HERO_ICONS_LIST.filter((item) => [HERO_ICONS.tag, HERO_ICONS.account].includes(item.code)),
+      ),
+
+      dashboard: {
+        firstDayOfMonth: useLocalStorage('firstDayOfMonth', 1),
+        showAccountAmounts: useLocalStorage('showAccountAmounts', true),
+        showDecimal: useLocalStorage('showDecimals', false),
+        areEmptyAccountsVisible: useLocalStorage('areEmptyAccountsVisible', false),
+        excludedAccountsList: useLocalStorage('excludedAccountsList', []),
+        excludedCategoriesList: useLocalStorage('excludedCategoriesList', []),
+        excludedTagsList: useLocalStorage('excludedTagsList', []),
+      },
+    }
+  },
+
+  getters: {
+
+  },
+
+  actions: {
+
+    async fetchProfile() {
+      const response = await new ProfileRepository().getProfile()
+
+      if (response.data == null) {
+        return
+      }
+
+      const newValues = ProfileTransformer.transformFromApi(response.data)
+
+      // for (let key of PERSISTED_FIELDS.values()) {
+      //   if (!(key in newValues)) {
+      //     continue
+      //   }
+      //   if (NESTED_FIELDS.has(key)) {
+      //     for (let nestedKey of Object.keys(newValues[key])) {
+      //       this.$state[key][nestedKey] = newValues[key][nestedKey]
+      //     }
+      //   } else {
+      //     this.$state[key] = newValues[key]
+      //   }
+      // }
+    },
+
+    async writeProfile() {
+      const data = {}
+      // for (let key of PERSISTED_FIELDS.values()) {
+      //   if (NESTED_FIELDS.has(key)) {
+      //     data[key] = {}
+      //     for (let nestedKey of Object.keys(this.$state[key])) {
+      //       data[key][nestedKey] = this.$state[key][nestedKey]
+      //     }
+      //   } else {
+      //     data[key] = this.$state[key]
+      //   }
+      // }
+      await new ProfileRepository().writeProfile(ProfileTransformer.transformToApi(data))
+    },
+  },
+})

--- a/front/transformers/TransactionTransformer.js
+++ b/front/transformers/TransactionTransformer.js
@@ -1,7 +1,7 @@
 import _, { uniq, get } from 'lodash'
 import ApiTransformer from './ApiTransformer'
 import DateUtils from '~/utils/DateUtils'
-import { useAppStore } from '~/stores/appStore'
+import { useProfileStore } from '~/stores/profileStore'
 import { useDataStore } from '~/stores/dataStore'
 import Transaction from '~/models/Transaction'
 import Tag from '~/models/Tag'
@@ -55,7 +55,7 @@ export default class TransactionTransformer extends ApiTransformer {
   }
 
   static transformToApi(item) {
-    const appStore = useAppStore()
+    const profileStore = useProfileStore()
 
     let id = _.get(item, 'data.id')
     let newTransactions = item.attributes.transactions
@@ -83,8 +83,8 @@ export default class TransactionTransformer extends ApiTransformer {
       // newItem.type = transformedTransactionType
 
       let tags = item.tags ?? []
-      if (!id && appStore.autoAddedTags && appStore.autoAddedTags.length > 0) {
-        tags = [...tags, ...appStore.autoAddedTags]
+      if (!id && profileStore.autoAddedTags && profileStore.autoAddedTags.length > 0) {
+        tags = [...tags, ...profileStore.autoAddedTags]
       }
       tags = tags.map((tag) => Tag.getDisplayNameEllipsized(tag))
       tags = uniq(tags)

--- a/front/utils/DashboardUtils.js
+++ b/front/utils/DashboardUtils.js
@@ -5,11 +5,11 @@ import Category from '~/models/Category.js'
 import Account from '~/models/Account.js'
 
 export function getExcludedTransactionFilters() {
-  const appStore = useAppStore()
+  const profileStore = useProfileStore()
 
-  let excludedTags = appStore.dashboard.excludedTagsList.map((tag) => Tag.getDisplayName(tag))
-  let excludedCategories = appStore.dashboard.excludedCategoriesList.map((category) => Category.getDisplayName(category))
-  let excludedAccounts = appStore.dashboard.excludedAccountsList.map((account) => Account.getDisplayName(account))
+  let excludedTags = profileStore.dashboard.excludedTagsList.map((tag) => Tag.getDisplayName(tag))
+  let excludedCategories = profileStore.dashboard.excludedCategoriesList.map((category) => Category.getDisplayName(category))
+  let excludedAccounts = profileStore.dashboard.excludedAccountsList.map((account) => Account.getDisplayName(account))
 
   return [
     ...excludedTags.map((tagName) => `-tag_is:"${tagName}"`),
@@ -19,11 +19,11 @@ export function getExcludedTransactionFilters() {
 }
 
 export function getExcludedTransactionUrl() {
-  const appStore = useAppStore()
+  const profileStore = useProfileStore()
 
-  let excludedTags = appStore.dashboard.excludedTagsList.map((tag) => tag.id)
-  let excludedCategories = appStore.dashboard.excludedCategoriesList.map((category) => category.id)
-  let excludedAccounts = appStore.dashboard.excludedAccountsList.map((account) => account.id)
+  let excludedTags = profileStore.dashboard.excludedTagsList.map((tag) => tag.id)
+  let excludedCategories = profileStore.dashboard.excludedCategoriesList.map((category) => category.id)
+  let excludedAccounts = profileStore.dashboard.excludedAccountsList.map((account) => account.id)
 
   let list = [
     ...excludedTags.map((tagId) => `excluded_tag_id=${tagId}`),

--- a/front/utils/DateUtils.js
+++ b/front/utils/DateUtils.js
@@ -67,13 +67,13 @@ class DateUtils {
   }
 
   static dateToUI(date) {
-    const appStore = useAppStore()
-    return this.dateToString(date, appStore.dateFormat)
+    const profileStore = useProfileStore()
+    return this.dateToString(date, profileStore.dateFormat)
   }
 
   static dateToUIWithTime(date) {
-    const appStore = useAppStore()
-    return this.dateToString(date, `${appStore.dateFormat} HH:mm`)
+    const profileStore = useProfileStore()
+    return this.dateToString(date, `${profileStore.dateFormat} HH:mm`)
   }
 }
 

--- a/front/utils/MathUtils.js
+++ b/front/utils/MathUtils.js
@@ -6,14 +6,14 @@ export const NUMBER_FORMAT = {
 }
 
 export const getFormattedValue = (value, digits = 0) => {
-  const appStore = useAppStore()
-  if (!appStore.dashboard.showAccountAmounts) {
+  const profileStore = useProfileStore()
+  if (!profileStore.dashboard.showAccountAmounts) {
     return '******'
   }
-  if (appStore.dashboard.showDecimal) {
+  if (profileStore.dashboard.showDecimal) {
     digits = 2
   }
-  let numberFormatCode = appStore.numberFormat.code ?? NUMBER_FORMAT.eu.code
+  let numberFormatCode = profileStore.numberFormat.code ?? NUMBER_FORMAT.eu.code
   return new Intl.NumberFormat(numberFormatCode, { minimumFractionDigits: digits, maximumFractionDigits: digits }).format(value)
 }
 

--- a/front/utils/UIUtils.js
+++ b/front/utils/UIUtils.js
@@ -50,9 +50,9 @@ class UIUtils {
   }
 
   static showLoadingWhen(isLoading) {
-    const appStore = useAppStore()
+    const profileStore = useProfileStore()
     watch(isLoading, (newValue) => {
-      appStore.isLoading = newValue
+      profileStore.isLoading = newValue
     })
 
     // let loadingIndicator = null


### PR DESCRIPTION
* added option to disable sync settings to DB
* moved all profile settings to a separate Pinia store for better isolation
* show loading indicator while saving/loading profile settings
* improved functions that save/load settings => shorter and only use a whitelist of ignored properties
* dont persist `showAccountAmounts` to DB; it should be device specific.
* added `id` PK to `profiles` table.