### PR TITLE
Respect the Setting to Not Force Lower-Case Descriptions in the Transaction Assistant

### DIFF
--- a/front/components/transaction/transaction-assistant.vue
+++ b/front/components/transaction/transaction-assistant.vue
@@ -86,6 +86,7 @@
 
 <script setup>
 import { onMounted, watch } from 'vue'
+import { useProfileStore } from '~/stores/profileStore'
 import { useDataStore } from '~/stores/dataStore'
 import TransactionTemplate from '~/models/TransactionTemplate'
 import { debounce } from 'lodash/function'
@@ -178,7 +179,6 @@ const processAssistantText = () => {
     return
   }
 
-  text = LanguageUtils.removeAccents(text)
   text = RomanianLanguageUtils.fixBadWordNumbers(text)
   text = text.replace(',', '.')
   let words = text.split(' ')
@@ -202,6 +202,8 @@ const processAssistantText = () => {
   let indexOfLastAmount = words.findLastIndex((item) => isStringAMathExpression(item))
   // let searchWords = words.filter(item => !isStringAMathExpression(item)).join(' ')
   let searchWords = indexOfLastAmount < 0 ? words.join(' ') : words.slice(0, indexOfLastAmount).join(' ')
+  searchWords = LanguageUtils.removeAccentsAndForceLowerCase(searchWords)
+
   let descriptionWords =
     indexOfLastAmount < 0
       ? null
@@ -209,7 +211,13 @@ const processAssistantText = () => {
           .slice(indexOfLastAmount)
           .filter((item) => !isStringAMathExpression(item))
           .join(' ')
-  foundDescription.value = descriptionWords
+  descriptionWords = LanguageUtils.removeAccents(descriptionWords)
+
+  if (profileStore.lowerCaseTransactionDescription) {
+    foundDescription.value = LanguageUtils.forceLowerCase(descriptionWords)
+  } else {
+    foundDescription.value = descriptionWords
+  }
 
   // receivedWords = RomanianLanguageUtils.sanitize(receivedWords)
 

--- a/front/stores/dataStore.js
+++ b/front/stores/dataStore.js
@@ -206,7 +206,7 @@ export const useDataStore = defineStore('data', {
     },
 
     tagDictionaryByName: (state) => {
-      return keyBy(state.tagList, (item) => LanguageUtils.removeAccents(item.attributes.tag))
+      return keyBy(state.tagList, (item) => LanguageUtils.removeAccentsAndForceLowerCase(item.attributes.tag))
     },
 
     tagDictionaryById: (state) => {

--- a/front/transformers/TagTransformer.js
+++ b/front/transformers/TagTransformer.js
@@ -25,7 +25,7 @@ export default class TagTransformer extends ApiTransformer {
     }
 
     return {
-      tag: LanguageUtils.removeAccents(get(item, 'attributes.tag')),
+      tag: LanguageUtils.removeAccentsAndForceLowerCase(get(item, 'attributes.tag')),
       parent_id: get(item, 'attributes.parentTag.id'),
       icon: get(item, 'attributes.icon.icon', null),
       is_todo: get(item, 'attributes.is_todo', false),

--- a/front/transformers/TransactionTransformer.js
+++ b/front/transformers/TransactionTransformer.js
@@ -34,10 +34,10 @@ export default class TransactionTransformer extends ApiTransformer {
       transaction.accountSource = accountsDictionary[transaction['source_id']]
       transaction.accountDestination = accountsDictionary[transaction['destination_id']]
       transaction.category = categoryDictionary[transaction['category_id']]
-      // transaction.tags = TagTransformer.transformFromApiList(transaction.tags.map(tagName => tagDictionaryByName[LanguageUtils.removeAccents(tagName)]))
+      // transaction.tags = TagTransformer.transformFromApiList(transaction.tags.map(tagName => tagDictionaryByName[LanguageUtils.removeAccentsAndForceLowerCase(tagName)]))
       transaction.tags = transaction.tags.map((tagName) => {
-        hasMissingTag = hasMissingTag || !tagDictionaryByName[LanguageUtils.removeAccents(tagName)]
-        return tagDictionaryByName[LanguageUtils.removeAccents(tagName)]
+        hasMissingTag = hasMissingTag || !tagDictionaryByName[LanguageUtils.removeAccentsAndForceLowerCase(tagName)]
+        return tagDictionaryByName[LanguageUtils.removeAccentsAndForceLowerCase(tagName)]
       })
 
       // let subTransactionType = Transaction.transactionTypeFromFirefly(transaction.type)

--- a/front/utils/DataUtils.js
+++ b/front/utils/DataUtils.js
@@ -20,8 +20,8 @@ export const sortByPath = (list, path, isAsc = true) =>
 //   }
 //
 //   if (shouldRemoveAccents) {
-//     valueA = LanguageUtils.removeAccents(valueA)
-//     valueB = LanguageUtils.removeAccents(valueB)
+//     valueA = LanguageUtils.removeAccentsAndForceLowerCase(valueA)
+//     valueB = LanguageUtils.removeAccentsAndForceLowerCase(valueB)
 //   }
 //
 //   if (isNumeric) {

--- a/front/utils/LanguageUtils.js
+++ b/front/utils/LanguageUtils.js
@@ -6,6 +6,18 @@ export default class LanguageUtils {
     return text
       .normalize('NFD')
       .replace(/[\u0300-\u036f]/g, '')
-      .toLowerCase()
+  }
+
+  static forceLowerCase(text) {
+    if (!text) {
+      return ''
+    }
+    return text.toLowerCase()
+  }
+
+  static removeAccentsAndForceLowerCase(text) {
+    text = LanguageUtils.removeAccents(text)
+    text = LanguageUtils.forceLowerCase(text)
+    return text
   }
 }


### PR DESCRIPTION
The transaction assistant was not respecting my setting to not turn my descriptions into lower-case strings. Do you agree that the setting should be respected by the assistant?

It seemed like an easy fix. I did not test it though. I did not have the time to set up the entire environment.