### PR TITLE
Strip Accents Settings

### DIFF
--- a/front/components/transaction/transaction-assistant.vue
+++ b/front/components/transaction/transaction-assistant.vue
@@ -86,6 +86,7 @@
 
 <script setup>
 import { onMounted, watch } from 'vue'
+import { useProfileStore } from '~/stores/profileStore'
 import { useDataStore } from '~/stores/dataStore'
 import TransactionTemplate from '~/models/TransactionTemplate'
 import { debounce } from 'lodash/function'
@@ -178,7 +179,6 @@ const processAssistantText = () => {
     return
   }
 
-  text = LanguageUtils.removeAccents(text)
   text = RomanianLanguageUtils.fixBadWordNumbers(text)
   text = text.replace(',', '.')
   let words = text.split(' ')
@@ -202,6 +202,8 @@ const processAssistantText = () => {
   let indexOfLastAmount = words.findLastIndex((item) => isStringAMathExpression(item))
   // let searchWords = words.filter(item => !isStringAMathExpression(item)).join(' ')
   let searchWords = indexOfLastAmount < 0 ? words.join(' ') : words.slice(0, indexOfLastAmount).join(' ')
+  searchWords = LanguageUtils.removeAccentsAndForceLowerCase(searchWords)
+
   let descriptionWords =
     indexOfLastAmount < 0
       ? null
@@ -209,7 +211,13 @@ const processAssistantText = () => {
           .slice(indexOfLastAmount)
           .filter((item) => !isStringAMathExpression(item))
           .join(' ')
-  foundDescription.value = descriptionWords
+  descriptionWords = LanguageUtils.removeAccents(descriptionWords)
+
+  if (profileStore.lowerCaseTransactionDescription) {
+    foundDescription.value = LanguageUtils.forceLowerCase(descriptionWords)
+  } else {
+    foundDescription.value = descriptionWords
+  }
 
   // receivedWords = RomanianLanguageUtils.sanitize(receivedWords)
 

--- a/front/pages/accounts/[[id]].vue
+++ b/front/pages/accounts/[[id]].vue
@@ -115,10 +115,13 @@ const { name, type, role, currency, icon, includeNetWorth, isDashboardVisible } 
 const isRoleVisible = computed(() => get(type.value, 'fireflyCode') === Account.types.asset.fireflyCode)
 
 watch(name, (newValue) => {
-  if (!profileStore.lowerCaseAccountName) {
-    return
+  if (profileStore.lowerCaseAccountName) {
+    newValue = newValue.toLowerCase()
   }
-  name.value = newValue.toLowerCase()
+  if (profileStore.stripAccents) {
+    newValue = LanguageUtils.removeAccents(newValue)
+  }
+  name.value = newValue
 })
 
 const toolbar = useToolbar()

--- a/front/pages/categories/[[id]].vue
+++ b/front/pages/categories/[[id]].vue
@@ -80,10 +80,13 @@ const { name, icon } = generateChildren(item, [
 ])
 
 watch(name, (newValue) => {
-  if (!profileStore.lowerCaseCategoryName) {
-    return
+  if (profileStore.lowerCaseCategoryName) {
+    newValue = newValue.toLowerCase()
   }
-  name.value = newValue.toLowerCase()
+  if (profileStore.stripAccents) {
+    newValue = LanguageUtils.removeAccents(newValue)
+  }
+  name.value = newValue
 })
 
 const toolbar = useToolbar()

--- a/front/pages/settings/user-preferences-ui.vue
+++ b/front/pages/settings/user-preferences-ui.vue
@@ -27,6 +27,7 @@
       <van-cell-group inset>
         <!--        <div class="van-cell-group-title">Date settings:</div>-->
 
+        <app-boolean label="Strip accents:" v-model="stripAccents" />
         <app-boolean label="Force transaction description lowercase:" v-model="lowerCaseTransactionDescription" />
         <app-boolean label="Force account name lowercase:" v-model="lowerCaseAccountName" />
         <app-boolean label="Force category name lowercase:" v-model="lowerCaseCategoryName" />
@@ -57,6 +58,7 @@ const isDropdownNumberFormatVisible = ref(false)
 
 const darkTheme = ref(false)
 
+const stripAccents = ref(false)
 const lowerCaseTransactionDescription = ref(false)
 const lowerCaseAccountName = ref(false)
 const lowerCaseCategoryName = ref(false)
@@ -69,6 +71,7 @@ onMounted(() => {
 const onSave = async () => {
   profileStore.numberFormat = numberFormat.value
 
+  profileStore.stripAccents = stripAccents.value
   profileStore.lowerCaseTransactionDescription = lowerCaseTransactionDescription.value
   profileStore.lowerCaseAccountName = lowerCaseAccountName.value
   profileStore.lowerCaseCategoryName = lowerCaseCategoryName.value
@@ -85,6 +88,7 @@ const onSave = async () => {
 const init = () => {
   numberFormat.value = profileStore.numberFormat
 
+  stripAccents.value = profileStore.stripAccents
   lowerCaseTransactionDescription.value = profileStore.lowerCaseTransactionDescription
   lowerCaseAccountName.value = profileStore.lowerCaseAccountName
   lowerCaseCategoryName.value = profileStore.lowerCaseCategoryName

--- a/front/pages/tags/[[id]].vue
+++ b/front/pages/tags/[[id]].vue
@@ -136,9 +136,12 @@ const onRefresh = () => {
 }
 
 watch(tag, (newValue) => {
-  if (!profileStore.lowerCaseTagName) {
-    return
+  if (profileStore.lowerCaseTagName) {
+    newValue = newValue.toLowerCase()
   }
-  tag.value = newValue.toLowerCase()
+  if (profileStore.stripAccents) {
+    newValue = LanguageUtils.removeAccents(newValue)
+  }
+  tag.value = newValue
 })
 </script>

--- a/front/pages/transactions/[[id]].vue
+++ b/front/pages/transactions/[[id]].vue
@@ -366,10 +366,13 @@ watch(type, (newValue, oldValue) => {
 })
 
 watch(description, (newValue) => {
-  if (!profileStore.lowerCaseTransactionDescription) {
-    return
+  if (profileStore.lowerCaseTransactionDescription) {
+    newValue = newValue.toLowerCase()
   }
-  description.value = newValue.toLowerCase()
+  if (profileStore.stripAccents) {
+    newValue = LanguageUtils.removeAccents(newValue)
+  }
+  description.value = newValue
 })
 
 const showSourceAccountSuggestion = computed(() => !profileStore.defaultAccountSource && !accountSource.value)

--- a/front/stores/dataStore.js
+++ b/front/stores/dataStore.js
@@ -206,7 +206,7 @@ export const useDataStore = defineStore('data', {
     },
 
     tagDictionaryByName: (state) => {
-      return keyBy(state.tagList, (item) => LanguageUtils.removeAccents(item.attributes.tag))
+      return keyBy(state.tagList, (item) => LanguageUtils.removeAccentsAndForceLowerCase(item.attributes.tag))
     },
 
     tagDictionaryById: (state) => {

--- a/front/stores/profileStore.js
+++ b/front/stores/profileStore.js
@@ -43,6 +43,7 @@ export const useProfileStore = defineStore('profile', {
       lowerCaseAccountName: useLocalStorage('lowerCaseAccountName', false),
       lowerCaseCategoryName: useLocalStorage('lowerCaseCategoryName', true),
       lowerCaseTagName: useLocalStorage('lowerCaseTagName', true),
+      stripAccents: useLocalStorage('stripAccents', true),
 
       heroIcons: useLocalStorage(
         'heroIcons',

--- a/front/transformers/TagTransformer.js
+++ b/front/transformers/TagTransformer.js
@@ -25,7 +25,7 @@ export default class TagTransformer extends ApiTransformer {
     }
 
     return {
-      tag: LanguageUtils.removeAccentsAndForceLowerCase(get(item, 'attributes.tag')),
+      tag: get(item, 'attributes.tag'),
       parent_id: get(item, 'attributes.parentTag.id'),
       icon: get(item, 'attributes.icon.icon', null),
       is_todo: get(item, 'attributes.is_todo', false),

--- a/front/transformers/TagTransformer.js
+++ b/front/transformers/TagTransformer.js
@@ -25,7 +25,7 @@ export default class TagTransformer extends ApiTransformer {
     }
 
     return {
-      tag: LanguageUtils.removeAccents(get(item, 'attributes.tag')),
+      tag: LanguageUtils.removeAccentsAndForceLowerCase(get(item, 'attributes.tag')),
       parent_id: get(item, 'attributes.parentTag.id'),
       icon: get(item, 'attributes.icon.icon', null),
       is_todo: get(item, 'attributes.is_todo', false),

--- a/front/transformers/TransactionTransformer.js
+++ b/front/transformers/TransactionTransformer.js
@@ -34,10 +34,10 @@ export default class TransactionTransformer extends ApiTransformer {
       transaction.accountSource = accountsDictionary[transaction['source_id']]
       transaction.accountDestination = accountsDictionary[transaction['destination_id']]
       transaction.category = categoryDictionary[transaction['category_id']]
-      // transaction.tags = TagTransformer.transformFromApiList(transaction.tags.map(tagName => tagDictionaryByName[LanguageUtils.removeAccents(tagName)]))
+      // transaction.tags = TagTransformer.transformFromApiList(transaction.tags.map(tagName => tagDictionaryByName[LanguageUtils.removeAccentsAndForceLowerCase(tagName)]))
       transaction.tags = transaction.tags.map((tagName) => {
-        hasMissingTag = hasMissingTag || !tagDictionaryByName[LanguageUtils.removeAccents(tagName)]
-        return tagDictionaryByName[LanguageUtils.removeAccents(tagName)]
+        hasMissingTag = hasMissingTag || !tagDictionaryByName[LanguageUtils.removeAccentsAndForceLowerCase(tagName)]
+        return tagDictionaryByName[LanguageUtils.removeAccentsAndForceLowerCase(tagName)]
       })
 
       // let subTransactionType = Transaction.transactionTypeFromFirefly(transaction.type)

--- a/front/utils/DataUtils.js
+++ b/front/utils/DataUtils.js
@@ -20,8 +20,8 @@ export const sortByPath = (list, path, isAsc = true) =>
 //   }
 //
 //   if (shouldRemoveAccents) {
-//     valueA = LanguageUtils.removeAccents(valueA)
-//     valueB = LanguageUtils.removeAccents(valueB)
+//     valueA = LanguageUtils.removeAccentsAndForceLowerCase(valueA)
+//     valueB = LanguageUtils.removeAccentsAndForceLowerCase(valueB)
 //   }
 //
 //   if (isNumeric) {

--- a/front/utils/LanguageUtils.js
+++ b/front/utils/LanguageUtils.js
@@ -6,6 +6,18 @@ export default class LanguageUtils {
     return text
       .normalize('NFD')
       .replace(/[\u0300-\u036f]/g, '')
-      .toLowerCase()
+  }
+
+  static forceLowerCase(text) {
+    if (!text) {
+      return ''
+    }
+    return text.toLowerCase()
+  }
+
+  static removeAccentsAndForceLowerCase(text) {
+    text = LanguageUtils.removeAccents(text)
+    text = LanguageUtils.forceLowerCase(text)
+    return text
   }
 }


### PR DESCRIPTION
We use Firefly III in German. Many words have accents and we like them to not be stripped. I took the liberty and changed the code to add corresponding settings and respect the settings wherever necessary.

Do you agree that is could be a feature required by people?

I did not test the code since I did not have the time to set up the environment. Could you sanity-check my code and  run it on your system to check if it works?