### PR TITLE
Improved budgets rendering on dashboard and budget list

### DIFF
--- a/front/components/dashboard/dashboard-budgets/dashboard-budget-item.vue
+++ b/front/components/dashboard/dashboard-budgets/dashboard-budget-item.vue
@@ -6,7 +6,7 @@
     <template #text>
       <div class="display-flex flex-column align-items-center">
         <div class="font-600 text-size-12 text-center">{{ displayName }}</div>
-        <div class="font-500 text-size-10 text-center ">{{ budgetLimitSpent }} / {{ budgetAmount }}</div>
+        <div class="font-500 text-size-10 text-center ">{{ getFormattedValue(budgetLimitSpent) }} / {{ getFormattedValue(budgetAmount) }} {{ budgetCurrencySymbol }}</div>
         <div class="font-500 text-size-10 text-center text-muted">{{ budgetLimitInterval }} </div>
       </div>
     </template>
@@ -14,12 +14,11 @@
 </template>
 
 <script setup>
-import TablerIconConstants from '~/constants/TablerIconConstants.js'
-import Transaction from '~/models/Transaction.js'
 import { get } from 'lodash'
 import Budget from '~/models/Budget.js'
 import RouteConstants from '~/constants/RouteConstants.js'
 import BudgetLimit from '~/models/BudgetLimit.js'
+import { getFormattedValue } from '~/utils/MathUtils.js'
 
 const dataStore = useDataStore()
 
@@ -29,13 +28,10 @@ const props = defineProps({
 
 const budgetLimit = computed(() => Budget.getLimit(props.value))
 const displayName = computed(() => get(props.value, 'attributes.name', ' - '))
-const budgetType = computed(() => get(props.value, 'attributes.auto_budget_type.name', ' - '))
-const budgetPeriod = computed(() => get(props.value, 'attributes.auto_budget_period.name', ' - '))
 const budgetAmount = computed(() => get(props.value, 'attributes.amount', ' - '))
-const budgetLimitPercent = computed(() => get(budgetLimit.value, `attributes.percent`, 0))
 const budgetLimitSpent = computed(() => Math.abs(get(budgetLimit.value, `attributes.spent`, 0)))
 const budgetLimitInterval = computed(() => BudgetLimit.getLimitInterval(budgetLimit.value))
-
+const budgetCurrencySymbol = Budget.getCurrencySymbol(props.value)
 
 const onGoToBudget = async () => {
   let budgetId = get(props.value, 'id')

--- a/front/components/dashboard/dashboard-budgets/dashboard-budgets.vue
+++ b/front/components/dashboard/dashboard-budgets/dashboard-budgets.vue
@@ -17,8 +17,6 @@
 </template>
 
 <script setup>
-import TablerIconConstants from '~/constants/TablerIconConstants.js'
-import Transaction from '~/models/Transaction.js'
 import DashboardBudgetItem from '~/components/dashboard/dashboard-budgets/dashboard-budget-item.vue'
 
 const dataStore = useDataStore()

--- a/front/components/list-items/budget-list-item.vue
+++ b/front/components/list-items/budget-list-item.vue
@@ -13,7 +13,7 @@
           <div class="second_column flex-1 flex-column">
             <div v-if="displayName" class="title flex-center-vertical">
               <div class="flex-1">{{ displayName }}</div>
-              <div class="text-size-12">{{ budgetLimitSpent }} / {{ budgetAmount }}</div>
+              <div class="text-size-12">{{ budgetLimitSpent }} / {{ budgetAmount }} {{ budgetCurrencySymbol }}</div>
             </div>
 <!--            <bar-chart-item-horizontal :percent="budgetLimitPercent" class="p-0 mb-10" />-->
             <div class="display-flex flex-wrap gap-1 mt-5">
@@ -33,10 +33,7 @@
 
 <script setup>
 import _, { get } from 'lodash'
-import { useDataStore } from '~/stores/dataStore'
 import { useClickWithoutSwipe } from '~/composables/useClickWithoutSwipe'
-import TablerIconConstants from '~/constants/TablerIconConstants'
-import Account from '~/models/Account.js'
 import Budget from '~/models/Budget.js'
 import BudgetIcon from '~/components/budget/budget-icon.vue'
 
@@ -52,10 +49,8 @@ const displayName = computed(() => get(props.value, 'attributes.name', ' - '))
 const budgetType = computed(() => get(props.value, 'attributes.auto_budget_type.name', ' - '))
 const budgetPeriod = computed(() => get(props.value, 'attributes.auto_budget_period.name', ' - '))
 const budgetAmount = computed(() => get(props.value, 'attributes.amount', ' - '))
-const budgetLimitPercent = computed(() => get(budgetLimit.value, `attributes.percent`, 0))
 const budgetLimitSpent = computed(() => Math.abs(get(budgetLimit.value, `attributes.spent`, 0)))
-
-const icon = computed(() => Budget.getIcon(props.value))
+const budgetCurrencySymbol = Budget.getCurrencySymbol(props.value)
 
 const onEdit = async (e) => {
   emit('onEdit', props.value)

--- a/front/components/list-items/budget-list-item.vue
+++ b/front/components/list-items/budget-list-item.vue
@@ -48,7 +48,7 @@ const budgetLimit = computed(() => Budget.getLimit(props.value))
 const displayName = computed(() => get(props.value, 'attributes.name', ' - '))
 const budgetType = computed(() => get(props.value, 'attributes.auto_budget_type.name', ' - '))
 const budgetPeriod = computed(() => get(props.value, 'attributes.auto_budget_period.name', ' - '))
-const budgetAmount = computed(() => get(props.value, 'attributes.amount', ' - '))
+const budgetAmount = computed(() => get(props.value, 'attributes.amount', ' - ') || ' - ')
 const budgetLimitSpent = computed(() => Math.abs(get(budgetLimit.value, `attributes.spent`, 0)))
 const budgetCurrencySymbol = Budget.getCurrencySymbol(props.value)
 

--- a/front/models/Budget.js
+++ b/front/models/Budget.js
@@ -37,8 +37,15 @@ export default class Budget extends BaseModel {
 
   // --------
 
-  static getDisplayName(account) {
-    return _.get(account, 'attributes.name')
+  static getDisplayName(budget) {
+    return _.get(budget, 'attributes.name')
+  }
+
+  // --------
+
+  static getCurrencySymbol(budget) {
+    const dataStore = useDataStore()
+    return _.get(budget, 'attributes.currency.attributes.symbol', _.get(dataStore.defaultCurrency, 'attributes.symbol'));
   }
 
   // --------


### PR DESCRIPTION
Adding currency symbol and hiding amounts on dashboard when corresponding setting is enabled.
Note that you can create a budget in Firefly without "auto-budget" feature which is currently broken - both before and after this PR. Although I don't know if anyone actually uses that budget type.

![Screenshot 2024-09-25 at 20 13 27](https://github.com/user-attachments/assets/ce2cb3de-f979-405a-a199-bec6e8b6baca)
![Screenshot 2024-09-25 at 20 13 41](https://github.com/user-attachments/assets/24be26cf-f21a-4c16-b137-dc04fd782796)
![Screenshot 2024-09-25 at 20 19 04](https://github.com/user-attachments/assets/4c482937-75ab-47c9-a524-0c34744b5602)

Fixes #105