### PR TITLE
Fixed overflowing budget circle

### DIFF
--- a/front/components/budget/budget-icon.vue
+++ b/front/components/budget/budget-icon.vue
@@ -16,7 +16,7 @@ const props = defineProps({
 
 const icon = computed(() => Budget.getIcon(props.value))
 const budgetLimit = computed(() => Budget.getLimit(props.value))
-const budgetLimitPercent = computed(() => get(budgetLimit.value, `attributes.percent`) ?? 0)
+const budgetLimitPercent = computed(() => Math.min(get(budgetLimit.value, `attributes.percent`) ?? 0, 100))
 
 let colorsList = [
   // { start: 0, end: Infinity, colorWhite: '#E53935', colorDark: '#E53935' },


### PR DESCRIPTION
Fixes #111 

Works correctly now:
<img width="125" alt="Screenshot 2024-09-27 at 20 11 23" src="https://github.com/user-attachments/assets/cc06d53f-49fe-4445-8b3e-97ddcaff06cb">
