### PR TITLE
Add additional postgres environment variables

### DIFF
--- a/back/config/database.php
+++ b/back/config/database.php
@@ -74,8 +74,12 @@ return [
             'charset' => 'utf8',
             'prefix' => '',
             'prefix_indexes' => true,
-            'search_path' => 'public',
-            'sslmode' => 'prefer',
+            'search_path' => env('PGSQL_SCHEMA', 'public'),
+            'schema' => env('PGSQL_SCHEMA', 'public'),
+            'sslmode' => env('PGSQL_SSL_MODE', 'prefer'),
+            'sslcert' => env('PGSQL_SSL_CERT', ''),
+            'sslkey' => env('PGSQL_SSL_KEY', ''),
+            'sslrootcert' => env('PGSQL_SSL_ROOT_CERT'),
         ],
 
         'sqlsrv' => [


### PR DESCRIPTION
In my personal setup I use postgres with a TLS certificate. Firefly pico already supports this, but I am not able to set the SSL mode to verify-full to also validate the postgres TLS certificate.

I've added the variables, just like in firefly (https://github.com/cioraneanu/firefly-pico/blob/main/back/config/database.php#L66) and tested it locally.

First by setting SSL Mode to verify full `PGSQL_SSL_MODE=verify-full` and keeping `PGSQL_SSL_ROOT_CERT` empty, resulting in an expected fail:
```
...
Successfully connected to DB via TCP: example.com:5432                                                                                                                        
                                                                                                                                                                                              
In Connection.php line 801:                                                                                                                                                                   
                                                                                                                                                                                              
  SQLSTATE[08006] [7] connection to server at "example.com" (xxx.xxx.xxx.xxx), port 5432 failed: root certificate file "/root/.postgresql/root.crt" does not exist               
  Either provide the file, use the system's trusted roots with sslrootcert=system, or change sslmode to disable server certificate verification. (Connection: pgsql, SQL: select * from inf   
  ormation_schema.tables where table_catalog = firefly-pico and table_schema = public and table_name = migrations and table_type = 'BASE TABLE')                                              
                                                                                                                                                                                              
                                                                                                                                                                                              
In Connector.php line 65:                                                                                                                                                                     
                                                                                                                                                                                              
  SQLSTATE[08006] [7] connection to server at "example.com" (xxx.xxx.xxx.xxx), port 5432 failed: root certificate file "/root/.postgresql/root.crt" does not exist               
  Either provide the file, use the system's trusted roots with sslrootcert=system, or change sslmode to disable server certificate verification.                                              
                                                                                                                                                                                              
                                                                                                                                                                                              
                                                                                                                                                                                              
   INFO  Configuration cache cleared successfully.
...
```

Setting `PGSQL_SSL_ROOT_CERT`to `system` allows it to connect without issues.

```
Successfully connected to DB via TCP: example.com:5432

   INFO  Nothing to migrate.  


   INFO  Configuration cache cleared successfully.  


   INFO  Configuration cached successfully.  


   INFO  Application cache cleared successfully.
```