### PR TITLE
Fix handling split transactions for category chart

### DIFF
--- a/front/models/Transaction.js
+++ b/front/models/Transaction.js
@@ -107,6 +107,10 @@ class Transaction extends BaseModel {
     return get(transaction, 'attributes.transactions.0.category_id', 0)
   }
 
+  static getSplits(transaction) {
+    return get(transaction, 'attributes.transactions', [])
+  }
+
   static getAmountFormatted(transaction) {
     return this.getAmount(transaction).toFixed(2)
   }

--- a/front/stores/appStore.js
+++ b/front/stores/appStore.js
@@ -1,16 +1,9 @@
 import { defineStore } from 'pinia'
-import { StorageSerializers, useLocalStorage } from '@vueuse/core'
-import * as LanguageConstants from '~/constants/LanguageConstants'
-import DateUtils from '~/utils/DateUtils'
-import { FORM_CONSTANTS_TRANSACTION_FIELDS_LIST } from '~/constants/FormConstants'
+import { useLocalStorage } from '@vueuse/core'
 import ResponseUtils from '~/utils/ResponseUtils'
 import { compareVersionStrings } from '~/utils/DataUtils'
 import InfoRepository from '~/repository/InfoRepository.js'
 import { get } from 'lodash'
-import { HERO_ICONS, HERO_ICONS_LIST } from '~/constants/TransactionConstants.js'
-import { NUMBER_FORMAT } from '~/utils/MathUtils.js'
-import ProfileRepository from '~/repository/ProfileRepository'
-import ProfileTransformer from '~/transformers/ProfileTransformer'
 
 export const useAppStore = defineStore('app', {
   state: () => {


### PR DESCRIPTION
Counting splits separately so they correctly update each category

This should fix #143 