### PR TITLE
Added gray foreground color to items of disabled currencies.

### DIFF
--- a/front/assets/styles/theme-dark.css
+++ b/front/assets/styles/theme-dark.css
@@ -256,6 +256,10 @@
   color: var(--van-cell-text-color);
 }
 
+.van-theme-dark .list-item-disabled {
+  color: #707070;
+}
+
 /*.van-theme-dark .fake-input {*/
 /*  background: var(--van-background-2-5);*/
 /*}*/

--- a/front/assets/styles/theme.css
+++ b/front/assets/styles/theme.css
@@ -621,6 +621,10 @@ body {
     color: #000;
 }
 
+.list-item-disabled {
+    color: #999 !important;
+}
+
 .app-date-time .van-cell {
     padding: 0px !important;
 }

--- a/front/components/list-items/currency-list-item.vue
+++ b/front/components/list-items/currency-list-item.vue
@@ -2,9 +2,9 @@
   <van-swipe-cell ref="swipeCell" v-bind="clickWithoutSwipe">
     <van-cell>
       <template #title>
-        <div class="list-item-container">
+        <div class="list-item-container" :class="itemClass">
           <div class="first_column flex-center flex-column">
-            <app-icon :icon="TablerIconConstants.currency" :size="TablerIconConstants.sizeItemList" />
+            <app-icon :icon="TablerIconConstants.currency" :size="TablerIconConstants.sizeItemList" :class="itemClass" />
           </div>
 
           <div class="separator"></div>
@@ -37,6 +37,10 @@ const emit = defineEmits(['onEdit', 'onDelete'])
 const dataStore = useDataStore()
 
 const displayName = computed(() => _.get(props.value, 'attributes.name', ' - '))
+
+const itemClass = computed(() => ({
+  'list-item-disabled': !_.get(props.value, 'attributes.enabled', true)
+}))
 
 const onEdit = async (e) => {
   emit('onEdit', props.value)


### PR DESCRIPTION
Hi.

This pull request adds a visual distinction between disabled and enabled currencies.
Together with [the previous pull request](https://github.com/cioraneanu/firefly-pico/pull/162) you can see the following result on the screenshots.

<details><summary>Schreenshots</summary>


![image](https://github.com/user-attachments/assets/98bd7857-df33-435d-a4a4-a0b1e1ff8a81)

</details>
