### PR TITLE
Added possibility to interact with foreign currencies during transaction processing.

### DIFF
--- a/front/components/select/currency-dropdown.vue
+++ b/front/components/select/currency-dropdown.vue
@@ -1,7 +1,11 @@
 <template>
-  <van-popover v-model:show="showPopover" theme="dark" :actions="actions">
+  <van-popover v-model:show="showPopover" :actions="list" @select="onSelect">
     <template #reference>
-      <van-button type="primary">{{  }}</van-button>
+      <van-button type="success" size="small">{{ currencyCode }}</van-button>
+    </template>
+
+    <template #action="{ action }">
+      {{ Currency.getCode(action) }}
     </template>
   </van-popover>
 </template>
@@ -21,8 +25,7 @@ const showPopover = ref(false)
 const modelValue = defineModel()
 let list = ref([])
 
-
-const currencyCode = computed(() => {})
+const currencyCode = computed(() => Currency.getCode(modelValue.value))
 
 // ------ Methods ------
 
@@ -30,16 +33,8 @@ onMounted(async () => {
   list.value = dataStore.currenciesList.filter((item) => get(item, 'attributes.enabled'))
 })
 
-const getDisplayValue = (value) => {
-  return Currency.getDisplayName(value)
-}
-
-const isLoading = ref(false)
-UIUtils.showLoadingWhen(isLoading)
-const onRefresh = async () => {
-  isLoading.value = true
-  await dataStore.fetchCurrencies()
-  isLoading.value = false
+const onSelect = (item) => {
+  modelValue.value = item
 }
 </script>
 

--- a/front/components/select/currency-dropdown.vue
+++ b/front/components/select/currency-dropdown.vue
@@ -1,0 +1,46 @@
+<template>
+  <van-popover v-model:show="showPopover" theme="dark" :actions="actions">
+    <template #reference>
+      <van-button type="primary">{{  }}</van-button>
+    </template>
+  </van-popover>
+</template>
+
+<script setup>
+import _, { get } from 'lodash'
+import { useDataStore } from '~/stores/dataStore'
+import { useFormAttributes } from '~/composables/useFormAttributes'
+import { IconRefresh } from '@tabler/icons-vue'
+
+import Currency from '~/models/Currency'
+import TablerIconConstants from '~/constants/TablerIconConstants'
+
+const dataStore = useDataStore()
+
+const showPopover = ref(false)
+const modelValue = defineModel()
+let list = ref([])
+
+
+const currencyCode = computed(() => {})
+
+// ------ Methods ------
+
+onMounted(async () => {
+  list.value = dataStore.currenciesList.filter((item) => get(item, 'attributes.enabled'))
+})
+
+const getDisplayValue = (value) => {
+  return Currency.getDisplayName(value)
+}
+
+const isLoading = ref(false)
+UIUtils.showLoadingWhen(isLoading)
+const onRefresh = async () => {
+  isLoading.value = true
+  await dataStore.fetchCurrencies()
+  isLoading.value = false
+}
+</script>
+
+<style></style>

--- a/front/components/select/currency-select.vue
+++ b/front/components/select/currency-select.vue
@@ -57,25 +57,12 @@ const filteredList = computed(() => {
   })
 })
 
-// const categoryList = computed(() => {
-//   if (search.value.length === 0) {
-//     return dataStore.categoryList
-//   }
-//   return dataStore.categoryList.filter(item => {
-//     return Currency.getDisplayName(item).toUpperCase().indexOf(search.value.toUpperCase()) !== -1
-//   })
-// })
-
 // ------ Methods ------
 
 onMounted(async () => {
   list.value = dataStore.currenciesList.filter((item) => get(item, 'attributes.enabled'))
 })
 
-const onSelectCell = (value) => {
-  modelValue.value = value
-  showDropdown.value = false
-}
 
 const getDisplayValue = (value) => {
   return Currency.getDisplayName(value)

--- a/front/components/transaction/transaction-amount-field.vue
+++ b/front/components/transaction/transaction-amount-field.vue
@@ -4,7 +4,7 @@
     <div>
       <van-field
         required
-        v-model="modelValue"
+        v-model="amount"
         placeholder="Amount"
         @click="() => inputAmount.focus()"
         label="Amount"
@@ -25,7 +25,7 @@
 
         <template #input>
           <input
-            v-model="modelValue"
+            v-model="amount"
             @focus="onFocus"
             @blur="onBlur"
             ref="inputAmount"
@@ -64,7 +64,7 @@
         <!--      <app-icon :icon="SvgConstants.custom.exchange" style="width: 22px; margin-left: 16px" />-->
 
         <van-field
-          v-model="modelValueForeign"
+          v-model="amountForeign"
           placeholder="Foreign amount "
           @click="() => inputAmountForeign.focus()"
           label="Foreign amount"
@@ -82,7 +82,7 @@
 
           <template #input>
             <input
-              v-model="modelValueForeign"
+              v-model="amountForeign"
               ref="inputAmountForeign"
               style="width: 100%; border: none; background: transparent; height: 24px"
               type="text"
@@ -128,8 +128,10 @@ const profileStore = useProfileStore()
 const dataStore = useDataStore()
 const attrs = useAttrs()
 
-const modelValue = defineModel()
-const modelValueForeign = defineModel('foreign')
+const amount = defineModel('amount')
+const amountForeign = defineModel('amountForeign')
+const currencyForeign = defineModel('currencyForeign')
+// const modelValueForeign = defineModel('foreign')
 
 const props = defineProps({
   showQuickButtons: {
@@ -140,10 +142,6 @@ const props = defineProps({
     type: Object,
     default: null,
   },
-  currencyForeignId: {
-    type: String,
-    default: '',
-  },
   isForeignAmountVisible: {
     type: Boolean,
     default: false,
@@ -153,11 +151,6 @@ const props = defineProps({
     default: false,
   },
 })
-
-const currencyForeign = computed(() => {
-  const currency = dataStore.currenciesList.find(currency => currency.id === props.currencyForeignId);
-  return currency ? currency.attributes : null;
-});
 
 const transactionInputClass = computed(() => {
   return {
@@ -174,9 +167,9 @@ const quickButtons = profileStore.quickValueButtons
 const operatorsList = ref(['+', '-', '*', '/'])
 
 const onQuickButton = async (quickButton) => {
-  let value = !modelValue.value || modelValue.value === '' ? '0' : modelValue.value
+  let value = !amount.value || amount.value === '' ? '0' : amount.value
   value = parseInt(value)
-  modelValue.value = `${value + parseInt(quickButton)}`
+  amount.value = `${value + parseInt(quickButton)}`
 }
 
 const onFocus = () => {
@@ -185,7 +178,7 @@ const onFocus = () => {
 
 const onBlur = async () => {
   isInputFocused.value = false
-  modelValue.value = await evaluateModelValue(modelValue.value)
+  amount.value = await evaluateModelValue(amount.value)
 
   // On iOS if you hide the keyboard via the "Done" button, onBlur gets called but it's not actually blurred. This is a temp fix...
   inputAmount.value?.blur()
@@ -208,13 +201,13 @@ const evaluateModelValue = async (amount) => {
   return value
 }
 
-watch(modelValue, (newValue) => {
-  modelValue.value = sanitizeAmount(newValue)
+watch(amount, (newValue) => {
+  amount.value = sanitizeAmount(newValue)
 })
 
 const onOperation = async (operation) => {
-  modelValue.value = sanitizeAmount(modelValue.value + operation)
-  moveInputCursorToEnd(input, modelValue)
+  amount.value = sanitizeAmount(amount.value + operation)
+  moveInputCursorToEnd(input, amount)
 }
 
 const getConversionError = () => {
@@ -236,14 +229,14 @@ const convertAmountToForeign = () => {
   if (!isConversionValid()) {
     return
   }
-  modelValueForeign.value = convertCurrency(modelValue.value, props.currency.code, currencyForeign.value.code).toFixed(2)
+  amountForeign.value = convertCurrency(amount.value, props.currency.code, currencyForeign.value.code).toFixed(2)
 }
 
 const convertForeignToAmount = () => {
   if (!isConversionValid()) {
     return
   }
-  modelValue.value = convertCurrency(modelValueForeign.value, currencyForeign.value.code, props.currency.code).toFixed(2)
+  amount.value = convertCurrency(amountForeign.value, currencyForeign.value.code, props.currency.code).toFixed(2)
 }
 
 onMounted(() => {

--- a/front/components/transaction/transaction-amount-field.vue
+++ b/front/components/transaction/transaction-amount-field.vue
@@ -19,7 +19,7 @@
 
         <template #right-icon>
           <div class="flex-center-vertical gap-2">
-            {{ props.currency ? props.currency.symbol : '' }}
+            {{ currencySymbol ?? '' }}
           </div>
         </template>
 
@@ -61,8 +61,6 @@
 
       <!--    Foreign amount field    -->
       <div class="flex-center-vertical">
-        <!--      <app-icon :icon="SvgConstants.custom.exchange" style="width: 22px; margin-left: 16px" />-->
-
         <van-field
           v-model="amountForeign"
           placeholder="Foreign amount "
@@ -77,7 +75,7 @@
           </template>
 
           <template #right-icon>
-            {{ currencyForeign.symbol }}
+            {{ currencyForeignSymbol }}
           </template>
 
           <template #input>
@@ -92,6 +90,8 @@
           </template>
         </van-field>
       </div>
+
+      <currency-select label="DEMO! Foreign currency (Will be replaced with currency-dropdown)" v-model="currencyForeign" />
     </template>
 
     <table v-if="showQuickButtons && !disabled" class="transaction-amount-table-buttons">
@@ -123,6 +123,8 @@ import { useDataStore } from '~/stores/dataStore'
 import { moveInputCursorToEnd, sleep } from '~/utils/VueUtils'
 import { evalMath, removeEndOperators, sanitizeAmount } from '~/utils/MathUtils'
 import TablerIconConstants from '~/constants/TablerIconConstants.js'
+import { get } from 'lodash'
+import Currency from '~/models/Currency.js'
 
 const profileStore = useProfileStore()
 const dataStore = useDataStore()
@@ -131,7 +133,6 @@ const attrs = useAttrs()
 const amount = defineModel('amount')
 const amountForeign = defineModel('amountForeign')
 const currencyForeign = defineModel('currencyForeign')
-// const modelValueForeign = defineModel('foreign')
 
 const props = defineProps({
   showQuickButtons: {
@@ -151,6 +152,12 @@ const props = defineProps({
     default: false,
   },
 })
+
+const currencySymbol = computed(() => Currency.getSymbol(props.currency))
+const currencyForeignSymbol = computed(() => Currency.getSymbol(currencyForeign.value))
+
+const currencyCode = computed(() => Currency.getCode(props.currency))
+const currencyForeignCode = computed(() => Currency.getCode(currencyForeign.value))
 
 const transactionInputClass = computed(() => {
   return {
@@ -229,14 +236,14 @@ const convertAmountToForeign = () => {
   if (!isConversionValid()) {
     return
   }
-  amountForeign.value = convertCurrency(amount.value, props.currency.code, currencyForeign.value.code).toFixed(2)
+  amountForeign.value = convertCurrency(amount.value, currencyCode.value, currencyForeignCode.value).toFixed(2)
 }
 
 const convertForeignToAmount = () => {
   if (!isConversionValid()) {
     return
   }
-  amount.value = convertCurrency(amountForeign.value, currencyForeign.value.code, props.currency.code).toFixed(2)
+  amount.value = convertCurrency(amountForeign.value, currencyForeignCode.value, currencyCode.value).toFixed(2)
 }
 
 onMounted(() => {

--- a/front/components/transaction/transaction-amount-field.vue
+++ b/front/components/transaction/transaction-amount-field.vue
@@ -76,6 +76,7 @@
 
           <template #right-icon>
             {{ currencyForeignSymbol }}
+            <currency-dropdown v-model="currencyForeign" />
           </template>
 
           <template #input>
@@ -91,7 +92,6 @@
         </van-field>
       </div>
 
-      <currency-select label="DEMO! Foreign currency (Will be replaced with currency-dropdown)" v-model="currencyForeign" />
     </template>
 
     <table v-if="showQuickButtons && !disabled" class="transaction-amount-table-buttons">

--- a/front/components/transaction/transaction-amount-field.vue
+++ b/front/components/transaction/transaction-amount-field.vue
@@ -3,6 +3,7 @@
     <!--    Amount field    -->
     <div>
       <van-field
+        required
         v-model="modelValue"
         placeholder="Amount"
         @click="() => inputAmount.focus()"
@@ -10,6 +11,7 @@
         class="flex-center-vertical app-field transaction-amount-field"
         v-bind="attrs"
         label-align="top"
+        :rules="[{ required: true, message: 'Amount is required' }]"
       >
         <template #left-icon>
           <app-icon :icon="TablerIconConstants.cashBanknote" :size="20" />
@@ -75,7 +77,7 @@
           </template>
 
           <template #right-icon>
-            {{ props.currencyForeign ? props.currencyForeign.symbol : '' }}
+            {{ currencyForeign.symbol }}
           </template>
 
           <template #input>
@@ -138,9 +140,9 @@ const props = defineProps({
     type: Object,
     default: null,
   },
-  currencyForeign: {
-    type: Object,
-    default: null,
+  currencyForeignId: {
+    type: String,
+    default: '',
   },
   isForeignAmountVisible: {
     type: Boolean,
@@ -151,6 +153,11 @@ const props = defineProps({
     default: false,
   },
 })
+
+const currencyForeign = computed(() => {
+  const currency = dataStore.currenciesList.find(currency => currency.id === props.currencyForeignId);
+  return currency ? currency.attributes : null;
+});
 
 const transactionInputClass = computed(() => {
   return {
@@ -214,7 +221,7 @@ const getConversionError = () => {
   if (!props.currency) {
     return 'Source currency is required!'
   }
-  if (!props.currencyForeign) {
+  if (!currencyForeign.value) {
     return 'Foreign currency is required!'
   }
 }
@@ -229,14 +236,14 @@ const convertAmountToForeign = () => {
   if (!isConversionValid()) {
     return
   }
-  modelValueForeign.value = convertCurrency(modelValue.value, props.currency.code, props.currencyForeign.code).toFixed(2)
+  modelValueForeign.value = convertCurrency(modelValue.value, props.currency.code, currencyForeign.value.code).toFixed(2)
 }
 
 const convertForeignToAmount = () => {
   if (!isConversionValid()) {
     return
   }
-  modelValue.value = convertCurrency(modelValueForeign.value, props.currencyForeign.code, props.currency.code).toFixed(2)
+  modelValue.value = convertCurrency(modelValueForeign.value, currencyForeign.value.code, props.currency.code).toFixed(2)
 }
 
 onMounted(() => {

--- a/front/models/Account.js
+++ b/front/models/Account.js
@@ -31,7 +31,6 @@ class Account extends BaseModel {
   // ------------
 
   getFake(id) {
-
     if (process.env.NODE_ENV === 'production') {
       return {}
     }
@@ -146,16 +145,7 @@ class Account extends BaseModel {
     if (!account) {
       return null
     }
-    return {
-      code: get(account, 'attributes.currency_code'),
-      decimalPlaces: get(account, 'attributes.currency_decimal_places'),
-      id: get(account, 'attributes.currency_id'),
-      symbol: get(account, 'attributes.currency_symbol'),
-    }
-  }
-
-  static getCurrencyId(account) {
-    return get(account, 'attributes.currency_id')
+    return get(account, 'attributes.currency')
   }
 
   static getBalance(account) {

--- a/front/models/Account.js
+++ b/front/models/Account.js
@@ -147,10 +147,10 @@ class Account extends BaseModel {
       return null
     }
     return {
-      code : get(account, 'attributes.currency_code'),
-      decimalPlaces : get(account, 'attributes.currency_decimal_places'),
-      id : get(account, 'attributes.currency_id'),
-      symbol : get(account, 'attributes.currency_symbol'),
+      code: get(account, 'attributes.currency_code'),
+      decimalPlaces: get(account, 'attributes.currency_decimal_places'),
+      id: get(account, 'attributes.currency_id'),
+      symbol: get(account, 'attributes.currency_symbol'),
     }
   }
 

--- a/front/models/Currency.js
+++ b/front/models/Currency.js
@@ -35,10 +35,20 @@ class Currency extends BaseModel {
 
   // --------
 
-  static getDisplayName(account) {
-    const name = get(account, 'attributes.name')
-    const symbol = get(account, 'attributes.symbol')
-    return `${name}, ${symbol}`
+  static getSymbol(currency) {
+    return get(currency, 'attributes.symbol')
+  }
+
+  static getCode(currency) {
+    return get(currency, 'attributes.code')
+  }
+
+  static getName(currency) {
+    return get(currency, 'attributes.name')
+  }
+
+  static getDisplayName(currency) {
+    return `${this.getName(currency)}, ${this.getSymbol(currency)}`
   }
 }
 

--- a/front/models/Transaction.js
+++ b/front/models/Transaction.js
@@ -44,6 +44,7 @@ class Transaction extends BaseModel {
             accountDestination: profileStore.defaultAccountDestination,
             type: type,
             category: profileStore.defaultCategory,
+            currencyForeign: profileStore.defaultForeignCurrency
           },
         ],
       },

--- a/front/pages/settings/transactions/default-form-values.vue
+++ b/front/pages/settings/transactions/default-form-values.vue
@@ -13,6 +13,8 @@
         <tag-select v-model="defaultTags" label="Default tags (only preselected)" />
 
         <tag-select v-model="autoAddedTags" label="Auto tags (appended after creation)" />
+
+        <currency-select v-model="defaultForeignCurrency" label="Default foreign currency for Expense transactions" />
       </van-cell-group>
 
       <app-button-form-save />
@@ -37,6 +39,7 @@ const defaultAccountDestination = ref(null)
 const defaultCategory = ref(null)
 const defaultTags = ref([])
 const autoAddedTags = ref([])
+const defaultForeignCurrency = ref([])
 
 const syncedSettings = [
   { store: profileStore, path: 'defaultAccountSource', ref: defaultAccountSource },
@@ -44,6 +47,7 @@ const syncedSettings = [
   { store: profileStore, path: 'defaultCategory', ref: defaultCategory },
   { store: profileStore, path: 'defaultTags', ref: defaultTags },
   { store: profileStore, path: 'autoAddedTags', ref: autoAddedTags },
+  { store: profileStore, path: 'defaultForeignCurrency', ref: defaultForeignCurrency },
 ]
 
 watchSettingsStore(syncedSettings)

--- a/front/pages/transactions/[[id]].vue
+++ b/front/pages/transactions/[[id]].vue
@@ -19,15 +19,13 @@
         </div>
 
         <transaction-amount-field
-          required
           v-model="amount"
           v-model:foreign="amountForeign"
           :currency="sourceCurrency"
-          :currencyForeign="destinationCurrency"
+          :currencyForeignId="currencyForeignId"
           :isForeignAmountVisible="isForeignAmountVisible"
           ref="refAmount"
           name="amount"
-          :rules="[{ required: true, message: 'Amount is required' }]"
           :style="getStyleForField(FORM_CONSTANTS_TRANSACTION_FIELDS.TRANSACTION_FORM_FIELD_AMOUNT)"
           :disabled="isSplitTransaction"
         />
@@ -175,7 +173,7 @@ let { itemId, item, isEmpty, title, addButtonText, isLoading, onClickBack, saveI
 
 
 const pathKey = 'attributes.transactions.0'
-const { amount, amountForeign, date, tags, description, notes, budget, accountSource, accountDestination, category, type } = generateChildren(item, [
+const { amount, amountForeign, date, tags, description, notes, budget, accountSource, accountDestination, category, type, foreignCurrencyId } = generateChildren(item, [
   { computed: 'amount', parentKey: `${pathKey}.amount` },
   { computed: 'amountForeign', parentKey: `${pathKey}.amountForeign` },
   { computed: 'date', parentKey: `${pathKey}.date` },
@@ -187,6 +185,7 @@ const { amount, amountForeign, date, tags, description, notes, budget, accountSo
   { computed: 'category', parentKey: `${pathKey}.category` },
   { computed: 'type', parentKey: `${pathKey}.type` },
   { computed: 'budget', parentKey: `${pathKey}.budget` },
+  { computed: 'foreignCurrencyId', parentKey: `${pathKey}.foreignCurrencyId` },
 ])
 
 const transactions = computed(() => _.get(item.value, 'attributes.transactions', []))
@@ -197,9 +196,11 @@ const accountDestinationAllowedTypes = computed(() => Account.getAccountTypesFor
 // ------------------------------------
 
 const sourceCurrency = computed(() => Account.getCurrency(accountSource.value))
-const destinationCurrency = computed(() => Account.getCurrency(accountDestination.value))
+const currencyForeignId = computed(() => {
+  return foreignCurrencyId.value ? foreignCurrencyId.value : get(profileStore.defaultForeignCurrency, 'id', null)
+})
 const isForeignAmountVisible = computed(() => {
-  return accountSource.value && accountDestination.value && sourceCurrency.value.id !== destinationCurrency.value.id
+  return accountSource.value && currencyForeignId.value && sourceCurrency.value.id !== currencyForeignId.value
 })
 
 //

--- a/front/pages/transactions/[[id]].vue
+++ b/front/pages/transactions/[[id]].vue
@@ -198,9 +198,9 @@ const accountDestinationAllowedTypes = computed(() => Account.getAccountTypesFor
 const sourceCurrency = computed(() => Account.getCurrency(accountSource.value))
 
 const isForeignAmountVisible = computed(() => {
-  // TODO: Write me later
-  return true
-  // return accountSource.value && currencyForeignId.value && sourceCurrency.value.id !== currencyForeignId.value
+  let newTransactionWithDefaultCurrency = !itemId.value && profileStore.defaultForeignCurrency
+  let accountsHaveDifferentCurrencies = accountSource.value && accountDestination.value && Account.getCurrency(accountSource.value) !== Account.getCurrency(accountDestination.value)
+  return !!(newTransactionWithDefaultCurrency ||  accountsHaveDifferentCurrencies || currencyForeign.value)
 })
 
 //

--- a/front/pages/transactions/[[id]].vue
+++ b/front/pages/transactions/[[id]].vue
@@ -21,7 +21,7 @@
         <transaction-amount-field
           v-model:amount="amount"
           v-model:amountForeign="amountForeign"
-          v-model:currencyForeign="amountForeign"
+          v-model:currencyForeign="currencyForeign"
           :currency="sourceCurrency"
           :isForeignAmountVisible="isForeignAmountVisible"
           ref="refAmount"
@@ -173,9 +173,10 @@ let { itemId, item, isEmpty, title, addButtonText, isLoading, onClickBack, saveI
 
 
 const pathKey = 'attributes.transactions.0'
-const { amount, amountForeign, date, tags, description, notes, budget, accountSource, accountDestination, category, type, foreignCurrency } = generateChildren(item, [
+const { amount, amountForeign, date, tags, description, notes, budget, accountSource, accountDestination, category, type, currencyForeign } = generateChildren(item, [
   { computed: 'amount', parentKey: `${pathKey}.amount` },
   { computed: 'amountForeign', parentKey: `${pathKey}.amountForeign` },
+  { computed: 'currencyForeign', parentKey: `${pathKey}.currencyForeign` },
   { computed: 'date', parentKey: `${pathKey}.date` },
   { computed: 'tags', parentKey: `${pathKey}.tags` },
   { computed: 'description', parentKey: `${pathKey}.description` },
@@ -185,7 +186,6 @@ const { amount, amountForeign, date, tags, description, notes, budget, accountSo
   { computed: 'category', parentKey: `${pathKey}.category` },
   { computed: 'type', parentKey: `${pathKey}.type` },
   { computed: 'budget', parentKey: `${pathKey}.budget` },
-  { computed: 'foreignCurrency', parentKey: `${pathKey}.foreignCurrency` },
 ])
 
 const transactions = computed(() => _.get(item.value, 'attributes.transactions', []))

--- a/front/pages/transactions/[[id]].vue
+++ b/front/pages/transactions/[[id]].vue
@@ -19,10 +19,10 @@
         </div>
 
         <transaction-amount-field
-          v-model="amount"
-          v-model:foreign="amountForeign"
+          v-model:amount="amount"
+          v-model:amountForeign="amountForeign"
+          v-model:currencyForeign="amountForeign"
           :currency="sourceCurrency"
-          :currencyForeignId="currencyForeignId"
           :isForeignAmountVisible="isForeignAmountVisible"
           ref="refAmount"
           name="amount"
@@ -173,7 +173,7 @@ let { itemId, item, isEmpty, title, addButtonText, isLoading, onClickBack, saveI
 
 
 const pathKey = 'attributes.transactions.0'
-const { amount, amountForeign, date, tags, description, notes, budget, accountSource, accountDestination, category, type, foreignCurrencyId } = generateChildren(item, [
+const { amount, amountForeign, date, tags, description, notes, budget, accountSource, accountDestination, category, type, foreignCurrency } = generateChildren(item, [
   { computed: 'amount', parentKey: `${pathKey}.amount` },
   { computed: 'amountForeign', parentKey: `${pathKey}.amountForeign` },
   { computed: 'date', parentKey: `${pathKey}.date` },
@@ -185,7 +185,7 @@ const { amount, amountForeign, date, tags, description, notes, budget, accountSo
   { computed: 'category', parentKey: `${pathKey}.category` },
   { computed: 'type', parentKey: `${pathKey}.type` },
   { computed: 'budget', parentKey: `${pathKey}.budget` },
-  { computed: 'foreignCurrencyId', parentKey: `${pathKey}.foreignCurrencyId` },
+  { computed: 'foreignCurrency', parentKey: `${pathKey}.foreignCurrency` },
 ])
 
 const transactions = computed(() => _.get(item.value, 'attributes.transactions', []))
@@ -196,11 +196,11 @@ const accountDestinationAllowedTypes = computed(() => Account.getAccountTypesFor
 // ------------------------------------
 
 const sourceCurrency = computed(() => Account.getCurrency(accountSource.value))
-const currencyForeignId = computed(() => {
-  return foreignCurrencyId.value ? foreignCurrencyId.value : get(profileStore.defaultForeignCurrency, 'id', null)
-})
+
 const isForeignAmountVisible = computed(() => {
-  return accountSource.value && currencyForeignId.value && sourceCurrency.value.id !== currencyForeignId.value
+  // TODO: Write me later
+  return true
+  // return accountSource.value && currencyForeignId.value && sourceCurrency.value.id !== currencyForeignId.value
 })
 
 //

--- a/front/stores/profileStore.js
+++ b/front/stores/profileStore.js
@@ -30,6 +30,7 @@ export const useProfileStore = defineStore('profile', {
       defaultAccountSource: useLocalStorage('defaultAccountSource', null, { serializer: StorageSerializers.object }),
       defaultAccountDestination: useLocalStorage('defaultAccountDestination', null, { serializer: StorageSerializers.object }),
       defaultCategory: useLocalStorage('defaultCategory', null, { serializer: StorageSerializers.object }),
+      defaultForeignCurrency: useLocalStorage('defaultForeignCurrency', null, { serializer: StorageSerializers.object }),
 
       defaultTags: useLocalStorage('defaultTags', [], { serializer: StorageSerializers.object }),
       autoAddedTags: useLocalStorage('autoAddedTags', [], { serializer: StorageSerializers.object }),

--- a/front/transformers/TransactionTransformer.js
+++ b/front/transformers/TransactionTransformer.js
@@ -73,7 +73,7 @@ export default class TransactionTransformer extends ApiTransformer {
       newItem.amount = _.get(item, 'amount', 0)
 
       newItem.foreign_amount = _.get(item, 'amountForeign', 0)
-      newItem.foreign_currency_id = _.get(item, 'foreignCurrency.id')
+      newItem.foreign_currency_id = _.get(item, 'currencyForeign.id')
 
       newItem.description = get(item, 'description', '')
       newItem.notes = _.get(item, 'notes')

--- a/front/transformers/TransactionTransformer.js
+++ b/front/transformers/TransactionTransformer.js
@@ -32,6 +32,7 @@ export default class TransactionTransformer extends ApiTransformer {
       transaction.amount = Transaction.formatAmount(_.get(transaction, 'amount', 0))
       transaction.amountForeign = Transaction.formatAmount(_.get(transaction, 'foreign_amount', 0))
       transaction.foreignCurrencyId = get(transaction, 'foreign_currency_id')
+      transaction.foreignCurrency = transaction.foreignCurrencyId ? dataStore.currencyDictionary[transaction.foreignCurrencyId] : null
 
       transaction.date = DateUtils.autoToDate(transaction.date)
       transaction.accountSource = accountsDictionary[transaction['source_id']]
@@ -72,15 +73,7 @@ export default class TransactionTransformer extends ApiTransformer {
       newItem.amount = _.get(item, 'amount', 0)
 
       newItem.foreign_amount = _.get(item, 'amountForeign', 0)
-      newItem.foreign_currency_id = _.get(item, 'foreign_currency_id')
-      if (newItem.foreign_amount && !newItem.foreign_currency_id) {
-        const defaultForeignCurrencyId = _.get(profileStore.defaultForeignCurrency, 'id', null)
-        if (defaultForeignCurrencyId && accountSource && (defaultForeignCurrencyId !== Account.getCurrencyId(accountSource))) {
-          newItem.foreign_currency_id = defaultForeignCurrencyId
-        } else {
-          newItem.foreign_amount = null
-        }
-      }
+      newItem.foreign_currency_id = _.get(item, 'foreignCurrency.id')
 
       newItem.description = get(item, 'description', '')
       newItem.notes = _.get(item, 'notes')

--- a/front/transformers/TransactionTransformer.js
+++ b/front/transformers/TransactionTransformer.js
@@ -67,12 +67,20 @@ export default class TransactionTransformer extends ApiTransformer {
     newTransactions = newTransactions.map((item) => {
       const accountSource = _.get(item, 'accountSource')
       const accountDestination = _.get(item, 'accountDestination')
-      const hasDifferentCurrencies = accountSource && accountDestination && Account.getCurrencyId(accountSource) !== Account.getCurrencyId(accountDestination)
 
       let newItem = {}
       newItem.amount = _.get(item, 'amount', 0)
-      newItem.foreign_amount = hasDifferentCurrencies ? _.get(item, 'amountForeign', 0) : null
-      newItem.foreign_currency_id = hasDifferentCurrencies ? Account.getCurrencyId(accountDestination) : null
+
+      newItem.foreign_amount = _.get(item, 'amountForeign', 0)
+      newItem.foreign_currency_id = _.get(item, 'foreign_currency_id')
+      if (newItem.foreign_amount && !newItem.foreign_currency_id) {
+        const defaultForeignCurrencyId = _.get(profileStore.defaultForeignCurrency, 'id', null)
+        if (defaultForeignCurrencyId && accountSource && (defaultForeignCurrencyId !== Account.getCurrencyId(accountSource))) {
+          newItem.foreign_currency_id = defaultForeignCurrencyId
+        } else {
+          newItem.foreign_amount = null
+        }
+      }
 
       newItem.description = get(item, 'description', '')
       newItem.notes = _.get(item, 'notes')

--- a/front/transformers/TransactionTransformer.js
+++ b/front/transformers/TransactionTransformer.js
@@ -31,8 +31,8 @@ export default class TransactionTransformer extends ApiTransformer {
 
       transaction.amount = Transaction.formatAmount(_.get(transaction, 'amount', 0))
       transaction.amountForeign = Transaction.formatAmount(_.get(transaction, 'foreign_amount', 0))
-      transaction.foreignCurrencyId = get(transaction, 'foreign_currency_id')
-      transaction.foreignCurrency = transaction.foreignCurrencyId ? dataStore.currencyDictionary[transaction.foreignCurrencyId] : null
+      let currencyForeignId = get(transaction, 'foreign_currency_id')
+      transaction.currencyForeign = currencyForeignId ? dataStore.currencyDictionary[currencyForeignId] : null
 
       transaction.date = DateUtils.autoToDate(transaction.date)
       transaction.accountSource = accountsDictionary[transaction['source_id']]


### PR DESCRIPTION
Okay, this one's bigger.

In my case, the ability to specify expenses in foreign currency is important.
As you said [here](https://github.com/cioraneanu/firefly-pico/issues/99#issuecomment-2353625285), enabling such a feature for everyone would result in an overloaded interface (which is what the Firefly III frontend itself is now).

I thought about how this problem could be solved more elegantly, and came up with the following.
Let's add an option to set the default foreign currency.
So that if you are staying in some other country, you will most likely only need one specific foreign currency for the period of your stay. After country1 you may appear in country2, in which case the first foreign currency will no longer be needed and can be changed. Alternatively, after country1 you can come home and simply turn off the default foreign currency.

With the default foreign currency enabled, you will always see an input field for the foreign currency when creating a transaction, but it will now be optional.

Also, due to the new feature, it is now possible to change the amount of foreign currency when editing a transaction that already has a foreign currency expense specified.


Would be glad to have a detailed review and suggestions for correcting inaccuracies.

