### PR TITLE
Add en translation for several settings page

### DIFF
--- a/front/components/select/general/day-select.vue
+++ b/front/components/select/general/day-select.vue
@@ -1,7 +1,7 @@
 <template>
   <app-select
-    label="First day of the week"
-    popupTitle="Select the first day of the week"
+    :label="$t('day_select.label')"
+    :popupTitle="$t('day_select.title')"
     v-model="modelValue"
     v-model:showDropdown="showDropdown"
     :list="list"

--- a/front/components/select/general/language-select.vue
+++ b/front/components/select/general/language-select.vue
@@ -1,7 +1,7 @@
 <template>
   <app-select
-    label="Language select"
-    popupTitle="Select your language"
+    :label="$t('language_select.label')"
+    :popupTitle="$t('language_select.title')"
     v-model="modelValue"
     v-model:showDropdown="showDropdown"
     :list="list"

--- a/front/components/select/page-select.vue
+++ b/front/components/select/page-select.vue
@@ -1,5 +1,6 @@
 <template>
-  <app-select label="Starting page" v-model="modelValue" v-model:showDropdown="showDropdown" :list="list" :columns="1" v-bind="dynamicAttrs" :has-search="false" />
+  <app-select :label="$t('page_select.label')" :popupTitle="$t('page_select.title')" v-model="modelValue"
+    v-model:showDropdown="showDropdown" :list="list" :columns="1" v-bind="dynamicAttrs" :has-search="false" />
 </template>
 
 <script setup>

--- a/front/i18n/locales/en.json
+++ b/front/i18n/locales/en.json
@@ -34,9 +34,6 @@
   "amount": "Amount",
   "amount_min": "Amount min",
   "amount_max": "Amount max",
-  "ui": {
-    "theme": "Theme"
-  },
   "toolbar": {
     "home": "Home",
     "transactions": "Transactions",
@@ -68,5 +65,80 @@
     "title_clone_transaction": "Clone transaction",
     "title_edit_transaction": "Edit transaction",
     "title_add_transaction": "Add transaction"
+  },
+  "settings": {
+    "settings_title": "Settings",
+    "general": "General",
+    "required_field": "This field is required",
+    "settings_saved": "Settings saved",
+    "setup_entry": "Setup",
+    "setup": {
+      "title": "Setup",
+      "pico_backend_url": "Pico backend URL",
+      "sync_settings_via_token": "Sync settings across devices via token",
+      "days_between_sync": "Days between full sync of \"Extras\"",
+      "loaded_data_stats": "Loaded data stats",
+      "account": "Account",
+      "categories": "Categories",
+      "tags": "Tags",
+      "templates": "Templates",
+      "budgets": "Budgets",
+      "last_sync": "Last sync",
+      "verifying": "Verifying...",
+      "invalid_endpoint": "The provided endpoint is not correct.",
+      "invalid_token": "The provided token is not correct or expired.",
+      "fetching": "Fetching..."
+    },
+    "ui_entry": "User interface",
+    "ui": {
+      "theme": "Theme",
+      "title": "UI settings",
+      "reset_forms_after_creation": "Reset forms after creation",
+      "transaction_list": "Transaction list",
+      "select_hero_icons": "Select what Hero Icons to show",
+      "hero_icons": "Hero Icons",
+      "right_side_card": "(Right side card in the list)",
+      "dark": "Dark",
+      "light": "Light",
+      "user_preferences_saved": "User preferences saved"
+    },
+    "assistant_entry": "Assistant",
+    "assistant": {
+      "title": "Assistant settings",
+      "substring_todo_tag": "Substring which adds the todo tag"
+    },
+    "formatting_entry": "Formatting",
+    "formatting": {
+      "title": "Formatting settings",
+      "numbers_format": "Numbers formatting",
+      "select_numbers_format": "Select preferred numbers formatting",
+      "date_format": "Date format",
+      "select_date_format": "Select a date format",
+      "first_day_of_month": "First day of month",
+      "select_first_day_of_month": "Select the first day of month",
+      "casing": "Casing",
+      "force_transaction_description_lowercase": "Force transaction description lowercase",
+      "force_account_name_lowercase": "Force account name lowercase",
+      "force_category_name_lowercase": "Force category name lowercase",
+      "force_tag_name_lowercase": "Force tag name lowercase",
+      "strip_accents": "Strip accents"
+    },
+    "dashboard_entry": "Dashboard",
+    "transactions_entry": "Transactions",
+    "about_entry": "About",
+    "version": "Version",
+    "new_version_available": "New version available"
+  },
+  "page_select": {
+    "label": "Starting page",
+    "title": "Select your starting page"
+  },
+  "language_select": {
+    "title": "Select your language",
+    "label": "Language"
+  },
+  "day_select": {
+    "label": "First day of the week",
+    "title": "Select the first day of the week"
   }
 }

--- a/front/pages/settings/assistant.vue
+++ b/front/pages/settings/assistant.vue
@@ -4,9 +4,15 @@
 
     <van-form @submit="onSave" class="">
       <van-cell-group inset>
-        <div class="van-cell-group-title">General:</div>
+        <div class="van-cell-group-title">{{ $t('settings.general') }}:</div>
 
-        <app-field :icon="TablerIconConstants.fieldText2" v-model="assistantTodoTagMatcher" label="Substring which adds the todo tag" :rules="[{ required: true, message: 'This field is required' }]" required />
+        <app-field
+          :icon="TablerIconConstants.fieldText2"
+          v-model="assistantTodoTagMatcher"
+          :label="$t('settings.assistant.substring_todo_tag')"
+          :rules="[{ required: true, message: $t('settings.required_field') }]"
+          required
+        />
       </van-cell-group>
 
       <app-button-form-save />
@@ -25,6 +31,7 @@ import { NUMBER_FORMAT } from '~/utils/MathUtils.js'
 import TablerIconConstants from '~/constants/TablerIconConstants.js'
 import { saveSettingsToStore, watchSettingsStore } from '~/utils/SettingUtils.js'
 
+const { t } = useI18n()
 const profileStore = useProfileStore()
 const dataStore = useDataStore()
 
@@ -37,12 +44,12 @@ watchSettingsStore(syncedSettings)
 const onSave = async () => {
   saveSettingsToStore(syncedSettings)
   await profileStore.writeProfile()
-  UIUtils.showToastSuccess('Settings saved')
+  UIUtils.showToastSuccess(t('settings.settings_saved'))
 }
 
 const toolbar = useToolbar()
 toolbar.init({
-  title: 'Assistant settings',
+  title: t('settings.assistant.title'),
   backRoute: RouteConstants.ROUTE_SETTINGS,
 })
 

--- a/front/pages/settings/formatting.vue
+++ b/front/pages/settings/formatting.vue
@@ -4,24 +4,24 @@
 
     <van-form @submit="onSave" class="">
       <van-cell-group inset>
-        <div class="van-cell-group-title">General:</div>
+        <div class="van-cell-group-title">{{ $t('settings.general') }}:</div>
 
         <app-select
-          label="Numbers formatting:"
-          popupTitle="Select preferred numbers formatting"
+          :label="$t('settings.formatting.numbers_format') + ':'"
+          :popupTitle="$t('settings.formatting.select_numbers_format')"
           v-model="numberFormat"
           v-model:showDropdown="isDropdownNumberFormatVisible"
           :list="numberFormatList"
           :columns="1"
           :has-search="false"
-          :rules="[{ required: true, message: 'This field is required' }]"
+          :rules="[{ required: true, message: $t('settings.required_field') }]"
           required
           :clearable="false"
         />
 
         <app-select
-          label="Date format"
-          popupTitle="Select a date format"
+          :label="$t('settings.formatting.date_format')"
+          :popupTitle="$t('settings.formatting.select_date_format')"
           v-model="dateFormat"
           v-model:showDropdown="isDropdownDateFormatVisible"
           :list="dateFormatList"
@@ -32,8 +32,8 @@
         <day-select v-model="weekStartsOn" />
 
         <app-select
-          label="First day of month"
-          popupTitle="Select the first day of month"
+          :label="$t('settings.formatting.first_day_of_month')"
+          :popupTitle="$t('settings.formatting.select_first_day_of_month')"
           v-model="firstDayOfMonth"
           v-model:showDropdown="isDropdownFirstDayVisible"
           :list="firstDayOfMonthList"
@@ -43,13 +43,13 @@
       </van-cell-group>
 
       <van-cell-group inset>
-        <div class="van-cell-group-title">Casing:</div>
+        <div class="van-cell-group-title">{{ $t('settings.formatting.casing') }}:</div>
 
-        <app-boolean label="Force transaction description lowercase:" v-model="lowerCaseTransactionDescription" />
-        <app-boolean label="Force account name lowercase:" v-model="lowerCaseAccountName" />
-        <app-boolean label="Force category name lowercase:" v-model="lowerCaseCategoryName" />
-        <app-boolean label="Force tag name lowercase:" v-model="lowerCaseTagName" />
-        <app-boolean label="Strip accents:" v-model="stripAccents" />
+        <app-boolean :label="$t('settings.formatting.force_transaction_description_lowercase')" v-model="lowerCaseTransactionDescription" />
+        <app-boolean :label="$t('settings.formatting.force_account_name_lowercase')" v-model="lowerCaseAccountName" />
+        <app-boolean :label="$t('settings.formatting.force_category_name_lowercase')" v-model="lowerCaseCategoryName" />
+        <app-boolean :label="$t('settings.formatting.force_tag_name_lowercase')" v-model="lowerCaseTagName" />
+        <app-boolean :label="$t('settings.formatting.strip_accents')" v-model="stripAccents" />
       </van-cell-group>
 
       <app-button-form-save />
@@ -69,6 +69,7 @@ import TablerIconConstants from '~/constants/TablerIconConstants.js'
 import { saveSettingsToStore, watchSettingsStore } from '~/utils/SettingUtils.js'
 import DaySelect from '~/components/select/general/day-select.vue'
 
+const { t } = useI18n()
 const profileStore = useProfileStore()
 const dataStore = useDataStore()
 
@@ -109,12 +110,12 @@ watchSettingsStore(syncedSettings)
 const onSave = async () => {
   saveSettingsToStore(syncedSettings)
   await profileStore.writeProfile()
-  UIUtils.showToastSuccess('Settings saved')
+  UIUtils.showToastSuccess(t('settings.settings_saved'))
 }
 
 const toolbar = useToolbar()
 toolbar.init({
-  title: 'Formatting settings',
+  title: t('settings.formatting.title'),
   backRoute: RouteConstants.ROUTE_SETTINGS,
 })
 

--- a/front/pages/settings/index.vue
+++ b/front/pages/settings/index.vue
@@ -3,22 +3,22 @@
     <app-top-toolbar />
 
     <van-cell-group inset style="overflow: auto">
-      <app-field-link label="Setup" :icon="TablerIconConstants.settings" @click="navigateTo(RouteConstants.ROUTE_SETTINGS_SETUP)" />
-      <app-field-link label="User interface" :icon="TablerIconConstants.settingsUI" @click="navigateTo(RouteConstants.ROUTE_SETTINGS_UI)" />
-      <app-field-link label="Assistant" :icon="TablerIconConstants.assistant" @click="navigateTo(RouteConstants.ROUTE_SETTINGS_ASSISTANT)" />
-      <app-field-link label="Formatting" :icon="TablerIconConstants.fieldText1" @click="navigateTo(RouteConstants.ROUTE_SETTINGS_FORMATTING)" />
-      <app-field-link label="Dashboard" :icon="TablerIconConstants.dashboard" @click="navigateTo(RouteConstants.ROUTE_SETTINGS_DASHBOARD)" />
-      <app-field-link label="Transactions" :icon="TablerIconConstants.transaction" @click="navigateTo(RouteConstants.ROUTE_SETTINGS_TRANSACTION)" />
-      <app-field-link label="About" :icon="TablerIconConstants.settingsAbout" @click="navigateTo(RouteConstants.ROUTE_SETTINGS_ABOUT)" />
+      <app-field-link :label="$t('settings.setup_entry')" :icon="TablerIconConstants.settings" @click="navigateTo(RouteConstants.ROUTE_SETTINGS_SETUP)" />
+      <app-field-link :label="$t('settings.ui_entry')" :icon="TablerIconConstants.settingsUI" @click="navigateTo(RouteConstants.ROUTE_SETTINGS_UI)" />
+      <app-field-link :label="$t('settings.assistant_entry')" :icon="TablerIconConstants.assistant" @click="navigateTo(RouteConstants.ROUTE_SETTINGS_ASSISTANT)" />
+      <app-field-link :label="$t('settings.formatting_entry')" :icon="TablerIconConstants.fieldText1" @click="navigateTo(RouteConstants.ROUTE_SETTINGS_FORMATTING)" />
+      <app-field-link :label="$t('settings.dashboard_entry')" :icon="TablerIconConstants.dashboard" @click="navigateTo(RouteConstants.ROUTE_SETTINGS_DASHBOARD)" />
+      <app-field-link :label="$t('settings.transactions_entry')" :icon="TablerIconConstants.transaction" @click="navigateTo(RouteConstants.ROUTE_SETTINGS_TRANSACTION)" />
+      <app-field-link :label="$t('settings.about_entry')" :icon="TablerIconConstants.settingsAbout" @click="navigateTo(RouteConstants.ROUTE_SETTINGS_ABOUT)" />
     </van-cell-group>
 
     <div class="text-muted subtitle flex-center mt-20 flex-column">
       <div>
-        <a :href="REPO_URL">Version: {{ appStore.currentAppVersion }}</a>
+        <a :href="REPO_URL">{{$t('settings.version')}}: {{ appStore.currentAppVersion }}</a>
       </div>
 
       <div v-if="appStore.isNewVersionAvailable" class="latest-version-badge">
-        <a :href="REPO_URL">Newer version available: {{ appStore.latestAppVersion }} 🎉</a>
+        <a :href="REPO_URL">{{$t('settings.new_version_available')}}: {{ appStore.latestAppVersion }} 🎉</a>
       </div>
     </div>
     <div></div>
@@ -35,7 +35,8 @@ import TablerIconConstants from '~/constants/TablerIconConstants'
 const appStore = useAppStore()
 const toolbar = useToolbar()
 
-toolbar.init({ title: 'Settings' })
+const { t } = useI18n()
+toolbar.init({ title: t('settings.settings_title') })
 
 onMounted(() => {
   animateSettings()

--- a/front/pages/settings/setup.vue
+++ b/front/pages/settings/setup.vue
@@ -6,23 +6,22 @@
       <van-cell-group inset>
         <!--        <div class="van-cell-group-title">Setup</div>-->
 
-        <app-field left-icon="link-o" v-model="picoBackendURL" label="Pico backend URL" :rules="[{ required: true, message: 'This field is required' }]" required />
+        <app-field left-icon="link-o" v-model="picoBackendURL" :label="$t('settings.setup.pico_backend_url')" :rules="[{ required: true, message: $t('settings.required_field') }]" required />
         <settings-token-field v-model="authToken" required />
-        <app-boolean left-icon="points" label="Sync settings across devices via token" v-model="syncProfileInDB" />
-        <app-field v-model="daysBetweenFullSync" label='Days between full sync of "Extras"' :rules="[{ required: true, message: 'This field is required' }]" required />
-
+        <app-boolean left-icon="points" :label="$t('settings.setup.sync_settings_via_token')" v-model="syncProfileInDB" />
+        <app-field v-model="daysBetweenFullSync" :label="$t('settings.setup.days_between_sync')" :rules="[{ required: true, message: $t('settings.required_field') }]" required />
       </van-cell-group>
 
       <van-cell-group inset>
-        <div class="van-cell-group-title">Loaded data stats</div>
+        <div class="van-cell-group-title">{{ $t('settings.setup.loaded_data_stats') }}</div>
 
         <van-grid :column-num="3">
-          <app-config-stat :icon="TablerIconConstants.account" name="Account" :value="accountsCount" />
-          <app-config-stat :icon="TablerIconConstants.category" name="Categories" :value="categoriesCount" />
-          <app-config-stat :icon="TablerIconConstants.tag" name="Tags" :value="tagsCount" />
-          <app-config-stat :icon="TablerIconConstants.transactionTemplate" name="Templates" :value="transactionTemplatesCount" />
-          <app-config-stat :icon="TablerIconConstants.budget" name="Budgets" :value="budgetsCount" />
-          <app-config-stat :icon="TablerIconConstants.lastSync" name="Last sync" :value="lastSync" />
+          <app-config-stat :icon="TablerIconConstants.account" :name="$t('settings.setup.account')" :value="accountsCount" />
+          <app-config-stat :icon="TablerIconConstants.category" :name="$t('settings.setup.categories')" :value="categoriesCount" />
+          <app-config-stat :icon="TablerIconConstants.tag" :name="$t('settings.setup.tags')" :value="tagsCount" />
+          <app-config-stat :icon="TablerIconConstants.transactionTemplate" :name="$t('settings.setup.templates')" :value="transactionTemplatesCount" />
+          <app-config-stat :icon="TablerIconConstants.budget" :name="$t('settings.setup.budgets')" :value="budgetsCount" />
+          <app-config-stat :icon="TablerIconConstants.lastSync" :name="$t('settings.setup.last_sync')" :value="lastSync" />
         </van-grid>
       </van-cell-group>
 
@@ -64,6 +63,7 @@ const lastSync = computed(() => {
   }
   return DateUtils.dateToUIWithTime(dataStore.lastSync, DateUtils.FORMAT_ROMANIAN_DATE_HOUR_MINUTE)
 })
+const { t } = useI18n()
 
 onMounted(() => {
   authToken.value = appStore.authToken
@@ -80,33 +80,30 @@ const onSave = async () => {
   appStore.syncProfileInDB = syncProfileInDB.value
   appStore.daysBetweenFullSync = daysBetweenFullSync.value
 
-  UIUtils.showToastLoading('Verifying...')
+  UIUtils.showToastLoading(t('settings.setup.verifying'))
   let userResponse = await new UserRepository().getUser()
   UIUtils.stopToastLoading()
 
-
   if (!ResponseUtils.isSuccess(userResponse)) {
-    UIUtils.showToastError('The provided endpoint is not correct.')
+    UIUtils.showToastError(t('settings.setup.invalid_endpoint'))
     return
   }
 
   let userId = get(userResponse, 'data.data.id')
   if (!userId) {
-    UIUtils.showToastError('The provided token is not correct or expired.')
+    UIUtils.showToastError(t('settings.setup.invalid_token'))
     return
   }
 
-
-
-  UIUtils.showToastLoading('Fetching...')
+  UIUtils.showToastLoading(t('settings.setup.fetching'))
   await dataStore.syncEverything()
   UIUtils.stopToastLoading()
-  UIUtils.showToastSuccess('Settings saved')
+  UIUtils.showToastSuccess(t('settings.settings_saved'))
 }
 
 const toolbar = useToolbar()
 toolbar.init({
-  title: 'Setup',
+  title: t('settings.setup.title'),
   backRoute: RouteConstants.ROUTE_SETTINGS,
 })
 

--- a/front/pages/settings/ui.vue
+++ b/front/pages/settings/ui.vue
@@ -4,7 +4,7 @@
 
     <van-form @submit="onSave" class="">
       <van-cell-group inset>
-        <div class="van-cell-group-title mb-0">{{ $t('ui.theme') }}:</div>
+        <div class="van-cell-group-title mb-0">{{ $t('settings.ui.theme') }}:</div>
 
         <app-boolean :label="themeText" v-model="darkTheme">
           <template #icon="{ value }">
@@ -16,7 +16,7 @@
 
         <page-select v-model="startingPage"></page-select>
 
-        <app-boolean v-model="resetFormOnCreate" label="Reset forms after creation" />
+        <app-boolean v-model="resetFormOnCreate" :label="$t('settings.ui.reset_forms_after_creation')" />
       </van-cell-group>
 
       <app-button-form-save />
@@ -35,10 +35,11 @@ import TablerIconConstants from '~/constants/TablerIconConstants.js'
 import { saveSettingsToStore, watchSettingsStore } from '~/utils/SettingUtils.js'
 import LanguageSelect from '~/components/select/general/language-select.vue'
 
+const { t } = useI18n()
 const profileStore = useProfileStore()
 const dataStore = useDataStore()
 
-const themeText = computed(() => (darkTheme.value ? 'Dark' : 'Light'))
+const themeText = computed(() => (darkTheme.value ? t('settings.ui.dark') : t('settings.ui.light')))
 const darkTheme = ref(false)
 const startingPage = ref(null)
 const language = ref(null)
@@ -58,12 +59,12 @@ watchSettingsStore(syncedSettings)
 const onSave = async () => {
   saveSettingsToStore(syncedSettings)
   await profileStore.writeProfile()
-  UIUtils.showToastSuccess('User preferences saved')
+  UIUtils.showToastSuccess(t('settings.ui.user_preferences_saved'))
 }
 
 const toolbar = useToolbar()
 toolbar.init({
-  title: 'UI settings',
+  title: t('settings.ui.title'),
   backRoute: RouteConstants.ROUTE_SETTINGS,
 })
 


### PR DESCRIPTION
Add translation for several settings pages.

As discussed in #78, adding more translation. About, dashboard, transaction settings have yet not been included.