### PR TITLE
Add additional API for more exchange rates

### DIFF
--- a/back/app/Utils/CurrencyUtils.php
+++ b/back/app/Utils/CurrencyUtils.php
@@ -168,7 +168,24 @@ class CurrencyUtils
         ["code" => "YER", "name" => "Yemeni Rial", "country" => "Yemen"],
         ["code" => "ZAR", "name" => "South African Rand", "country" => "South Africa"],
         ["code" => "ZMW", "name" => "Zambian Kwacha", "country" => "Zambia"],
-        ["code" => "ZWL", "name" => "Zimbabwean Dollar", "country" => "Zimbabwe"]
+        ["code" => "ZWL", "name" => "Zimbabwean Dollar", "country" => "Zimbabwe"],
+
+        //Cryptocurrencies
+        ["code" => "BTC", "name" => "Bitcoin", "country" => "-"],
+        ["code" => "ETH", "name" => "Ethereum", "country" => "-"],
+        ["code" => "XRP", "name" => "Ripple XRP", "country" => "-"],
+        ["code" => "ADA", "name" => "Cardano", "country" => "-"],
+        ["code" => "DOT", "name" => "Polkadot", "country" => "-"],
+        ["code" => "BTC", "name" => "Bitcoin", "country" => "-"],
+        ["code" => "BNB", "name" => "Binance", "country" => "-"],
+        ["code" => "LTC", "name" => "Litecoin", "country" => "-"],
+
+        //Precious Metals
+        ["code" => "XAU", "name" => "Gold", "country" => "-"],
+        ["code" => "XAG", "name" => "Silver", "country" => "-"],
+        ["code" => "XPT", "name" => "Platinum", "country" => "-"],
+        ["code" => "XPD", "name" => "Palladium", "country" => "-"]
+
     ];
 
 }

--- a/front/components/dashboard/dashboard-budgets/dashboard-budget-item.vue
+++ b/front/components/dashboard/dashboard-budgets/dashboard-budget-item.vue
@@ -6,7 +6,7 @@
     <template #text>
       <div class="display-flex flex-column align-items-center">
         <div class="font-600 text-size-12 text-center">{{ displayName }}</div>
-        <div class="font-500 text-size-10 text-center">{{ getFormattedValue(budgetLimitSpent) }} / {{ getFormattedValue(budgetLimitAmount) }} {{ budgetCurrencySymbol }}</div>
+        <div class="font-500 text-size-10 text-center">{{ getFormattedValue(budgetLimitSpent,true) }} / {{ getFormattedValue(budgetLimitAmount,true) }} {{ budgetCurrencySymbol }}</div>
         <div class="font-500 text-size-10 text-center text-muted">{{ budgetLimitInterval }}</div>
       </div>
     </template>

--- a/front/components/dashboard/dashboard-budgets/dashboard-budgets.vue
+++ b/front/components/dashboard/dashboard-budgets/dashboard-budgets.vue
@@ -24,13 +24,14 @@ import { get } from 'lodash'
 import Transaction from '~/models/Transaction.js'
 import TablerIconConstants from '~/constants/TablerIconConstants.js'
 import AppChip from '~/components/ui-kit/app-chip.vue'
+import { getFormattedValue } from '~/utils/MathUtils.js'
 
 const dataStore = useDataStore()
 
 const budgetList = dataStore.budgetList
 const hasBudgets = computed(() => budgetList.length > 0)
 
-const budgetLimitTotalFormatted = computed(() => `${getFormattedValue(dataStore.budgetLimitTotal)} ${dataStore.dashboardCurrencyCode}`)
-const budgetLimitSpentFormatted = computed(() => `${getFormattedValue(dataStore.budgetLimitSpent)} ${dataStore.dashboardCurrencyCode}`)
-const budgetLimitRemainingFormatted = computed(() => `${getFormattedValue(dataStore.budgetLimitRemaining) } ${dataStore.dashboardCurrencyCode}`)
+const budgetLimitTotalFormatted = computed(() => `${getFormattedValue(dataStore.budgetLimitTotal,true)} ${dataStore.dashboardCurrencyCode}`)
+const budgetLimitSpentFormatted = computed(() => `${getFormattedValue(dataStore.budgetLimitSpent,true)} ${dataStore.dashboardCurrencyCode}`)
+const budgetLimitRemainingFormatted = computed(() => `${getFormattedValue(dataStore.budgetLimitRemaining,true) } ${dataStore.dashboardCurrencyCode}`)
 </script>

--- a/front/components/dashboard/dashboard-calendar/dashboard-calendar-month-day.vue
+++ b/front/components/dashboard/dashboard-calendar/dashboard-calendar-month-day.vue
@@ -41,17 +41,17 @@ const tdClass = computed(() => {
 
 const amountIncome = computed(() => {
   let value = get(dataStore.dashboardCalendarTransactionsByDate, `${formattedDate.value}.${Transaction.types.income.code}`)
-  return value ? getFormattedValue(value) : null
+  return value ? getFormattedValue(value,true) : null
 })
 
 const amountExpense = computed(() => {
   let value = get(dataStore.dashboardCalendarTransactionsByDate, `${formattedDate.value}.${Transaction.types.expense.code}`)
-  return value ? getFormattedValue(value) : null
+  return value ? getFormattedValue(value,true) : null
 })
 
 const amountTransfer = computed(() => {
   let value = get(dataStore.dashboardCalendarTransactionsByDate, `${formattedDate.value}.${Transaction.types.transfer.code}`)
-  return value ? getFormattedValue(value) : null
+  return value ? getFormattedValue(value,true) : null
 })
 
 const isCellEmpty = computed(() => {

--- a/front/components/dashboard/dashboard-category-totals/dashboard-category-totals.vue
+++ b/front/components/dashboard/dashboard-category-totals/dashboard-category-totals.vue
@@ -33,6 +33,7 @@ import TablerIconConstants from '~/constants/TablerIconConstants.js'
 import Category from '~/models/Category.js'
 import { getExcludedTransactionUrl } from '~/utils/DashboardUtils.js'
 import { useActionSheet } from '~/composables/useActionSheet.js'
+import { getFormattedValue } from '~/utils/MathUtils.js'
 
 const dataStore = useDataStore()
 
@@ -48,7 +49,7 @@ const barsList = computed(() => {
     return {
       category: category,
       label: category ? Category.getDisplayName(category) : 'Not set',
-      value: getFormattedValue(amount, 0),
+      value: getFormattedValue(amount, true),
       percent: percent,
     }
   })

--- a/front/components/dashboard/dashboard-summary/dashboard-summary.vue
+++ b/front/components/dashboard/dashboard-summary/dashboard-summary.vue
@@ -45,6 +45,7 @@ import TablerIconConstants from '~/constants/TablerIconConstants.js'
 import { addMonths, differenceInDays, startOfDay, subDays, subMonths } from 'date-fns'
 import RouteConstants from '~/constants/RouteConstants.js'
 import Transaction from '~/models/Transaction.js'
+import { getFormattedValue } from '~/utils/MathUtils.js'
 
 const profileStore = useProfileStore()
 const dataStore = useDataStore()
@@ -68,10 +69,10 @@ const remainingDays = computed(() => {
   return differenceInDays(endDate.value, startOfDay(new Date())) + 1
 })
 
-const totalExpenseFormatted = computed(() => getFormattedValue(dataStore.totalExpenseThisMonth))
-const totalIncomeFormatted = computed(() => getFormattedValue(dataStore.totalIncomeThisMonth))
-const totalTransferFormatted = computed(() => getFormattedValue(dataStore.totalTransfersThisMonth))
-const totalSurplusFormatted = computed(() => getFormattedValue(dataStore.totalSurplusThisMonth))
+const totalExpenseFormatted = computed(() => getFormattedValue(dataStore.totalExpenseThisMonth,true))
+const totalIncomeFormatted = computed(() => getFormattedValue(dataStore.totalIncomeThisMonth,true))
+const totalTransferFormatted = computed(() => getFormattedValue(dataStore.totalTransfersThisMonth,true))
+const totalSurplusFormatted = computed(() => getFormattedValue(dataStore.totalSurplusThisMonth,true))
 
 const onGoToTransactionsByType = async (transactionType) => {
   let excludedUrl = getExcludedTransactionUrl()

--- a/front/components/dashboard/dashboard-tag-totals/dashboard-tag-totals.vue
+++ b/front/components/dashboard/dashboard-tag-totals/dashboard-tag-totals.vue
@@ -38,6 +38,7 @@ import Tag from '~/models/Tag.js'
 import TablerIconConstants from '~/constants/TablerIconConstants.js'
 import { getExcludedTransactionUrl } from '~/utils/DashboardUtils.js'
 import { useActionSheet } from '~/composables/useActionSheet.js'
+import { getFormattedValue } from '~/utils/MathUtils.js'
 
 const dataStore = useDataStore()
 
@@ -60,7 +61,7 @@ const barsList = computed(() => {
       tag: tag,
       tag_id: tagId,
       label: tag ? Tag.getDisplayNameEllipsized(tag) : 'Not set',
-      value: getFormattedValue(amount, 0),
+      value: getFormattedValue(amount,true),
       percent: percent,
     }
   })

--- a/front/components/dashboard/dashboard-week-bars/dashboard-week-bars.vue
+++ b/front/components/dashboard/dashboard-week-bars/dashboard-week-bars.vue
@@ -16,6 +16,7 @@ import { get } from 'lodash'
 import RouteConstants from '~/constants/RouteConstants.js'
 import Transaction from '~/models/Transaction.js'
 import { getExcludedTransactionUrl } from '~/utils/DashboardUtils.js'
+import { getFormattedValue } from '~/utils/MathUtils.js'
 
 const dataStore = useDataStore()
 
@@ -35,7 +36,7 @@ const barsList = computed(() => {
     return {
       date: date,
       label: weekdayName,
-      value: getFormattedValue(amount, 0),
+      value: getFormattedValue(amount,true),
       percent: percent,
     }
   })

--- a/front/components/transaction/transaction-amount-field.vue
+++ b/front/components/transaction/transaction-amount-field.vue
@@ -247,14 +247,14 @@ const convertAmountToForeign = () => {
   if (!isConversionValid()) {
     return
   }
-  amountForeign.value = convertCurrency(amount.value, currencyCode.value, currencyForeignCode.value).toFixed(2)
+  amountForeign.value = parseFloat(convertCurrency(amount.value, currencyCode.value, currencyForeignCode.value).toFixed(10))
 }
 
 const convertForeignToAmount = () => {
   if (!isConversionValid()) {
     return
   }
-  amount.value = convertCurrency(amountForeign.value, currencyForeignCode.value, currencyCode.value).toFixed(2)
+  amount.value = parseFloat(convertCurrency(amountForeign.value, currencyForeignCode.value, currencyCode.value).toFixed(10))
 }
 
 onMounted(() => {

--- a/front/models/Transaction.js
+++ b/front/models/Transaction.js
@@ -113,7 +113,7 @@ class Transaction extends BaseModel {
   }
 
   static getAmountFormatted(transaction) {
-    return this.getAmount(transaction).toFixed(2)
+    return parseFloat(getAmount(transaction).toFixed(10))
   }
 
   static getDate(transaction) {
@@ -121,7 +121,7 @@ class Transaction extends BaseModel {
   }
 
   static formatAmount(amount) {
-    return (Math.round(amount * 100) / 100).toFixed(2)
+    return parseFloat(( Math.round(amount * 10000000000) / 10000000000 ).toFixed(10))
   }
 
   static getTransactionTypeForAccounts({ source, destination }) {

--- a/front/stores/dataStore.js
+++ b/front/stores/dataStore.js
@@ -114,8 +114,7 @@ export const useDataStore = defineStore('data', {
         .reduce((result, currencyCode) => {
           const currencyAmount = this.dashboardAccountsTotalByCurrency[currencyCode]
           return result + convertCurrency(currencyAmount, currencyCode, Currency.getCode(state.dashboardCurrency))
-        }, 0)
-        .toFixed(2)
+        }, 0).toFixed(2)
     },
 
     dashboardExpensesByCategory(state) {
@@ -219,7 +218,7 @@ export const useDataStore = defineStore('data', {
     transactionsListSavingsAmount(state) {
       let amountIn = convertTransactionsTotalAmountToCurrency(this.transactionsListSavingsIn, Currency.getCode(state.dashboardCurrency))
       let amountOut = convertTransactionsTotalAmountToCurrency(this.transactionsListSavingsOut, Currency.getCode(state.dashboardCurrency))
-      return amountIn - amountOut
+      return (amountIn - amountOut).toFixed(2)
     },
 
     transactionsListSavingsPercentage(state) {

--- a/front/utils/MathUtils.js
+++ b/front/utils/MathUtils.js
@@ -6,18 +6,19 @@ export const NUMBER_FORMAT = {
   international: { name: '1234.56 -> 1,234.56', code: 'en-EN' },
 }
 
-export const getFormattedValue = (value, digits = 0) => {
+export const getFormattedValue = (value, trim = false, minDigits = 0, maxDigits = 0 ) => {
   const profileStore = useProfileStore()
   if (!profileStore.dashboard.showAccountAmounts) {
     return '******'
   }
   if (profileStore.dashboard.showDecimal) {
-    digits = 2
+    minDigits = 2
+    maxDigits = (trim)?2:10
   }
   let numberFormatCode = profileStore.numberFormat.code ?? NUMBER_FORMAT.eu.code
   return new Intl.NumberFormat(numberFormatCode, {
-    minimumFractionDigits: digits,
-    maximumFractionDigits: digits,
+    minimumFractionDigits: minDigits,
+    maximumFractionDigits: maxDigits,
   }).format(value)
 }
 
@@ -48,7 +49,7 @@ export const evalMath = (value) => {
 
   try {
     let sanitizedValue = sanitizeMathString(value)
-    let newValue = parser.evaluate(sanitizedValue).toFixed(2)
+    let newValue = parseFloat(parser.evaluate(sanitizedValue).toFixed(10))
     return {
       wasSuccessful: true,
       hasChanged: newValue !== value,


### PR DESCRIPTION
Proposed Changes:
 - A new API (https://api.fxratesapi.com/latest) to provide exchange rates for popular cryptocurrencies and precious metals
 - Increase decimal precision to better accommodate small amounts

These changes are useful to monitor assets like cryptocurrencies and precious metals. 
The increased decimal precision is needed to monitor small amounts like for example BTC holdings

Feel free to do any adjustments based on your preference