### PR TITLE
save transactionslist page filters in localstorage as a single object

### DIFF
--- a/front/pages/transactions/list.vue
+++ b/front/pages/transactions/list.vue
@@ -116,9 +116,7 @@ watch(filters, (newValue, oldValue) => {
 })
 
 const saveFiltersToProfile = () => {
-  profileStore.transactionListDefaultFilterAccount = filters.value.account ?? null
-  profileStore.transactionListDefaultFilterDateStart = filters.value.dateStart ?? null
-  profileStore.transactionListDefaultFilterDateEnd = filters.value.dateEnd ?? null
+  profileStore.transactionListFilters = filters.value
 }
 
 const onClearFilters = () => {

--- a/front/stores/profileStore.js
+++ b/front/stores/profileStore.js
@@ -39,9 +39,8 @@ export const useProfileStore = defineStore('profile', {
       defaultTags: useLocalStorage('defaultTags', [], { serializer: StorageSerializers.object }),
       autoAddedTags: useLocalStorage('autoAddedTags', [], { serializer: StorageSerializers.object }),
 
-      transactionListDefaultFilterAccount: useLocalStorage('transactionListDefaultFilterAccount', null, { serializer: StorageSerializers.object }),
-      transactionListDefaultFilterDateStart: useLocalStorage('transactionListDefaultFilterDateStart', null),
-      transactionListDefaultFilterDateEnd: useLocalStorage('transactionListDefaultFilterDateEnd', null),
+      // Transaction list filters - stored as single object for simplicity
+      transactionListFilters: useLocalStorage('transactionListFilters', {}, { serializer: StorageSerializers.object }),
 
       isForeignCurrencyAlwaysVisible: useLocalStorage('isForeignCurrencyAlwaysVisible', false),
 

--- a/front/utils/TransactionFilterUtils.js
+++ b/front/utils/TransactionFilterUtils.js
@@ -143,12 +143,7 @@ export default {
 
   getPredefinedFilters() {
     let profileStore = useProfileStore()
-
-    return {
-      account: profileStore.transactionListDefaultFilterAccount,
-      dateStart: profileStore.transactionListDefaultFilterDateStart,
-      dateEnd: profileStore.transactionListDefaultFilterDateEnd,
-    }
+    return profileStore.transactionListFilters
   },
 
   getValuesFromDictionary(value, dictionary) {


### PR DESCRIPTION
Simplifies transaction list filter storage by consolidating three separate 
localStorage keys into a single `transactionListFilters` object.

**Changes:**
- Replace individual filter properties (`transactionListDefaultFilterAccount`, 
  `transactionListDefaultFilterDateStart`, `transactionListDefaultFilterDateEnd`) 
  with a unified `transactionListFilters` object in profileStore
- Update `TransactionFilterUtils.getPredefinedFilters()` to return the 
  consolidated filters object