### PR TITLE
fix: update PostgreSQL volume mount point

### DIFF
--- a/docker-compose.pico+firefly+importer.yml
+++ b/docker-compose.pico+firefly+importer.yml
@@ -22,7 +22,7 @@ services:
       firefly:
 
   firefly-pico-postgresql:
-    image: postgres:latest
+    image: postgres:18
     container_name: firefly_pico_db
     restart: always
     environment:
@@ -30,7 +30,7 @@ services:
       - POSTGRES_USER=firefly-pico
       - POSTGRES_PASSWORD=very-secure-pwd-pico
     volumes:
-      - /<your_path>/firefly-pico-db:/var/lib/postgresql/data
+      - /<your_path>/firefly-pico-db:/var/lib/postgresql
     networks:
       firefly:
 
@@ -60,7 +60,7 @@ services:
       firefly:
 
   firefly-app-postgresql:
-    image: postgres:latest
+    image: postgres:18
     container_name: firefly_iii_db
     restart: always
     environment:
@@ -68,7 +68,7 @@ services:
       - POSTGRES_USER=firefly
       - POSTGRES_PASSWORD=very-secure-pwd-firefly
     volumes:
-      - /<your_path>/firefly-db:/var/lib/postgresql/data
+      - /<your_path>/firefly-db:/var/lib/postgresql
     networks:
       firefly:
 

--- a/docker-compose.pico+firefly.yml
+++ b/docker-compose.pico+firefly.yml
@@ -22,7 +22,7 @@ services:
       firefly:
 
   firefly-pico-postgresql:
-    image: postgres:latest
+    image: postgres:18
     container_name: firefly_pico_db
     restart: always
     environment:
@@ -30,7 +30,7 @@ services:
       - POSTGRES_USER=firefly-pico
       - POSTGRES_PASSWORD=very-secure-pwd-pico
     volumes:
-      - /<your_path>/firefly-pico-db:/var/lib/postgresql/data
+      - /<your_path>/firefly-pico-db:/var/lib/postgresql
     networks:
       firefly:
 
@@ -60,7 +60,7 @@ services:
       firefly:
 
   firefly-app-postgresql:
-    image: postgres:latest
+    image: postgres:18
     container_name: firefly_iii_db
     restart: always
     environment:
@@ -68,7 +68,7 @@ services:
       - POSTGRES_USER=firefly
       - POSTGRES_PASSWORD=very-secure-pwd-firefly
     volumes:
-      - /<your_path>/firefly-db:/var/lib/postgresql/data
+      - /<your_path>/firefly-db:/var/lib/postgresql
     networks:
       firefly:
 

--- a/docker-compose.pico.yml
+++ b/docker-compose.pico.yml
@@ -21,14 +21,14 @@ services:
       - firefly
 
   firefly-pico-postgresql:
-    image: postgres:latest
+    image: postgres:18
     container_name: firefly_pico_db
     environment:
       - POSTGRES_DB=firefly-pico
       - POSTGRES_USER=firefly-pico
       - POSTGRES_PASSWORD=very-secure-pwd
     volumes:
-      - /<your_path>:/var/lib/postgresql/data
+      - /<your_path>:/var/lib/postgresql
     networks:
       - firefly
 


### PR DESCRIPTION
PostgreSQL have changed the way to handle data (see [this issue](https://github.com/docker-library/postgres/pull/1259)) with 18. So the current compose example files will not work out of the box. With this PR, `postgres` images are pinned to major **18** and volume mount points are being corrected.

For older installation, I have also wrote a brief guide to upgrade on this [comment](https://github.com/cioraneanu/firefly-pico/issues/241#issuecomment-3649844098)