### PR TITLE
Replaced the hardcoded "surplus" string with a dynamic 

### DIFF
--- a/front/components/dashboard/dashboard-summary/dashboard-summary.vue
+++ b/front/components/dashboard/dashboard-summary/dashboard-summary.vue
@@ -27,7 +27,7 @@
         subtitleClass="text-primary"
       />
 
-      <dashboard-summary-card :icon="TablerIconConstants.dashboardTotalSurplus" title="Surplus" :subtitle="totalSurplusFormatted" subtitleClass="" />
+      <dashboard-summary-card :icon="TablerIconConstants.dashboardTotalSurplus" :title="$t('dashboard.transactions_summary.surplus')" :subtitle="totalSurplusFormatted" subtitleClass="" />
       <dashboard-summary-card :icon="TablerIconConstants.dashboardTransactionsCount" :title="$t('toolbar.transactions')" :subtitle="dataStore.totalTransactionsCount" subtitleClass="" />
       <dashboard-summary-card :icon="TablerIconConstants.account" :title="$t('dashboard.transactions_summary.days_remaining')" :subtitle="remainingDays" />
     </van-grid>


### PR DESCRIPTION
Replaced the hardcoded "surplus" string with a dynamic $t() call to ensure translation is correctly displayed on the dashboard summary card.