### PR TITLE
Add style class to preserve field order

### DIFF
--- a/front/pages/transactions/[[id]].vue
+++ b/front/pages/transactions/[[id]].vue
@@ -13,7 +13,7 @@
     <transaction-type-tabs v-model="type" class="mx-3 mt-1 mb-1" />
 
     <van-form :disabled="isSplitTransaction" :name="formName" class="transaction-form-group" ref="form" @submit="saveItem" @failed="onValidationError">
-      <van-cell-group inset class="dynamic-masonry">
+      <van-cell-group inset class="dynamic-masonry display-flex-column">
         <div v-if="isSplitTransaction" class="display-flex ml-3 mt-3">
           <transaction-split-badge />
         </div>


### PR DESCRIPTION
FIX: A style class is added because the order of the fields was not being preserved.
<img width="643" height="650" alt="image" src="https://github.com/user-attachments/assets/776256aa-e948-4f7e-9317-5a7766cdf471" />
<img width="655" height="460" alt="image" src="https://github.com/user-attachments/assets/562535d5-0a55-48fc-83b6-8b3c3b72e4b1" />
