### PR TITLE
ADD: Remaining budget, with a red limit if exceeded

### DIFF
--- a/front/components/dashboard/dashboard-budgets/dashboard-budget-item.vue
+++ b/front/components/dashboard/dashboard-budgets/dashboard-budget-item.vue
@@ -7,6 +7,7 @@
       <div class="display-flex flex-column align-items-center">
         <div class="font-600 text-size-12 text-center">{{ displayName }}</div>
         <div class="font-500 text-size-10 text-center">{{ formatNumberForDashboard(budgetLimitSpent) }} / {{ formatNumberForDashboard(budgetLimitAmount) }} {{ budgetCurrencySymbol }}</div>
+        <div class="font-500 text-size-10 text-center" :style="isOverBudget ? 'color: var(--expense2)' : ''">{{ formatNumberForDashboard(budgetLimitRemaining) }} {{ budgetCurrencySymbol }}</div>
         <div class="font-500 text-size-10 text-center text-muted">{{ budgetLimitInterval }}</div>
       </div>
     </template>
@@ -30,6 +31,8 @@ const budgetLimit = computed(() => Budget.getLimit(props.value))
 const displayName = computed(() => get(props.value, 'attributes.name', ' - '))
 const budgetLimitSpent = computed(() => Math.abs(get(budgetLimit.value, `attributes.spent`, 0)))
 const budgetLimitAmount = computed(() => get(budgetLimit.value, 'attributes.amount') ?? 0)
+const budgetLimitRemaining = computed(() => get(budgetLimit.value, 'attributes.remaining', 0))
+const isOverBudget = computed(() => budgetLimitRemaining.value < 0)
 const budgetLimitInterval = computed(() => BudgetLimit.getLimitInterval(budgetLimit.value))
 const budgetCurrencySymbol = computed(() => Budget.getCurrencySymbol(props.value))
 


### PR DESCRIPTION
It shows the remaining budget, and if the budget is exceeded, it displays the amount in red, just to make it clearer in case the numbers are large.

<img width="230" height="243" alt="image" src="https://github.com/user-attachments/assets/d4bbc109-36bf-42d1-b030-e99f001a45b8" />

I know how to subtract, but it seems like a subtle point to me