### PR TITLE
FIX: stop dropping saved default accounts on new-transaction form load

### DIFF
--- a/front/models/Transaction.js
+++ b/front/models/Transaction.js
@@ -154,22 +154,23 @@ export default class Transaction extends BaseModel {
     return this.types.expense
   }
 
+  // Keep each account if still valid for the new type; otherwise reuse the
+  // other slot's account if it fits. Allow-lists come from Account so the
+  // form and this repair stay in lockstep.
   static attemptAccountFixOnTypeChange(newType, sourceAccount, destinationAccount) {
-    let firstAsset = [sourceAccount, destinationAccount].find((account) => Account.getType(account)?.fireflyCode === Account.types.asset.fireflyCode)
+    const allowedSources = Account.getAccountTypesForTransactionTypeSource(newType).map((t) => t.fireflyCode)
+    const allowedDestinations = Account.getAccountTypesForTransactionTypeDestination(newType).map((t) => t.fireflyCode)
 
-    switch (newType.code) {
-      case Transaction.types.income.code:
-        let source = [sourceAccount, destinationAccount].find((account) => [Account.types.liability.fireflyCode, Account.types.revenue.fireflyCode, Account.types.cash.fireflyCode].includes(Account.getType(account)?.fireflyCode))
-        return { source: source, destination: firstAsset }
+    const fits = (account, allowed) => !!account && allowed.includes(Account.getType(account)?.fireflyCode)
 
-      case Transaction.types.expense.code:
-        let destination = [sourceAccount, destinationAccount].find((account) => {
-          return [Account.types.liability.fireflyCode, Account.types.expense.fireflyCode, Account.types.cash.fireflyCode].includes(Account.getType(account)?.fireflyCode)
-        })
-        return { source: firstAsset, destination: destination }
-      case Transaction.types.transfer.code:
-        let otherAsset = [sourceAccount, destinationAccount].find((account) => firstAsset?.id !== account?.id && Account.getType(account)?.code === Account.types.asset.code)
-        return { source: firstAsset, destination: otherAsset }
-    }
+    const pool = [sourceAccount, destinationAccount].filter(Boolean)
+    // Compare by id so a Transfer can't end up with the same account in both
+    // slots even if the two refs are distinct objects with the same id.
+    const pickFitting = (allowed, exclude) => pool.find((a) => a?.id !== exclude?.id && fits(a, allowed)) ?? null
+
+    const source = fits(sourceAccount, allowedSources) ? sourceAccount : pickFitting(allowedSources, null)
+    const destination = fits(destinationAccount, allowedDestinations) && destinationAccount?.id !== source?.id ? destinationAccount : pickFitting(allowedDestinations, source)
+
+    return { source, destination }
   }
 }

--- a/front/pages/transactions/[[id]].vue
+++ b/front/pages/transactions/[[id]].vue
@@ -366,8 +366,10 @@ const accountDestinationBinding = computed(() => {
 })
 
 watch(type, (newValue, oldValue) => {
-  // Only when creating a transaction
-  if (itemId.value) {
+  // Only react to real user-driven tab switches on the new-transaction form.
+  // On initial form population, oldValue is undefined and the saved defaults
+  // are still being settled — running the repair there silently dropped them.
+  if (itemId.value || !oldValue || isEqual(newValue, oldValue)) {
     return
   }
   attemptAccountsFix()


### PR DESCRIPTION
## The bug

Saved defaults `source=Liability, destination=Expense`. Open the new-transaction form. They come back as `source=null, destination=Liability` — the Expense default just disappears.

`attemptAccountFixOnTypeChange` was meant to fire only on user-driven tab switches (per its comment), but it actually fires on initial form population too. And its hardcoded "find the asset" branches have no idea what to do with two non-asset defaults — Liability happens to match the destination allow-list first, so it gets promoted into destination and Expense gets stomped.

## Why it matters for us
We use Firefly for our shared flat finances and each flatmate has a liability account. If they buy something for the flat at the store with their own money they track it as an Expense going from their personal liability account to a specific expense account (e.g. groceries).

## Fix idea

- Don't run the repair on the initial reactive flip; only on real type changes.
- Replace the asset-centric branches with: ask `Account.getAccountTypesForTransactionType{Source,Destination}` whether each account is still valid where it sits. If yes, leave it. If not, see if the other slot's account would fit. Same allow-list the dropdowns already use, so what counts as "valid" stays in one place.

## Old vs new

Notation: `(src, dst)`; `_` = cleared.

| input | switch → | old | new |
|---|---|---|---|
| **Liab, Expense** (defaults — the bug) | init expense | `(_, Liab)` | `(Liab, Expense)` |
| Asset, Expense | income | `(_, Asset)` | `(_, Asset)` |
| Asset, Expense | transfer | `(Asset, _)` | `(Asset, _)` |
| Revenue, Asset | expense | `(Asset, _)` | `(Asset, _)` |
| Revenue, Asset | transfer | `(Asset, _)` | `(Asset, _)` |
| AssetA, AssetB | expense | `(AssetA, _)` | `(AssetA, _)` |
| Liab, Expense | income | `(Liab, _)` | `(Liab, _)` |
| Cash, Cash | transfer | `(_, _)` | `(_, _)` |
| AssetA, AssetB | income | `(_, AssetA)` | `(_, AssetB)` |
| Liab, Expense | transfer | `(_, _)` | `(Liab, _)` |
| Liab, Liab | expense | `(_, Liab)` | `(Liab, _)` |

Bottom three are the behavioral differences:

- **AssetA, AssetB → Income**: new keeps the destination-slot asset where it was. Old picked first-found.
- **Liab, Expense → Transfer**: Liability is actually valid as a Transfer source per the allow-lists. Old `firstAsset`-only logic dropped it; new keeps it.
- **Liab, Liab → Expense**: same account can't sit in both slots. Old kept it in destination, new keeps it in source.