### PR TITLE
FIX: translate transaction source/destination account labels to German

### DIFF
--- a/front/i18n/locales/de-DE.json
+++ b/front/i18n/locales/de-DE.json
@@ -81,8 +81,8 @@
       "income": "Einkommen",
       "transfer": "Transfer"
     },
-    "source_account": "Source account",
-    "destination_account": "Destination account",
+    "source_account": "Quell-Konto",
+    "destination_account": "Ziel-Konto",
     "make_template": "Template erstellen",
     "configure_fields": "Felder konfigurieren",
     "title_clone_transaction": "Transaktion duplizieren",


### PR DESCRIPTION
`transaction.source_account` and `transaction.destination_account` in `de-DE.json` still hold their English defaults, so the new-transaction form renders "Source account" / "Destination account" in the German UI.

Translated to `"Quell-Konto"` / `"Ziel-Konto"` — matches the hyphenated convention already used by `settings.transactions.default_form_values.default_source_account` and `default_destination_account` in the same file.