### PR TITLE
feat: add option to hide floating mobile profile button

### DIFF
--- a/front/i18n/locales/de-DE.json
+++ b/front/i18n/locales/de-DE.json
@@ -132,6 +132,7 @@
       "theme": "Theme",
       "title": "UI Einstellungen",
       "show_animations": "Animationen anzeigen",
+      "is_profile_float_visible": "Profil-Button auf Dashboard anzeigen",
       "reset_forms_after_creation": "Formulare nach Erzeugung zurücksetzten",
       "transaction_list": "Transaktions-Liste",
       "select_hero_icons": "Auswählen welche Hero Icons angzeig werden",

--- a/front/i18n/locales/en.json
+++ b/front/i18n/locales/en.json
@@ -132,6 +132,7 @@
       "theme": "Theme",
       "title": "UI settings",
       "show_animations": "Show animations",
+      "is_profile_float_visible": "Show profile floating button on dashboard",
       "reset_forms_after_creation": "Reset forms after creation",
       "transaction_list": "Transaction list",
       "select_hero_icons": "Select what Hero Icons to show",

--- a/front/layouts/default.vue
+++ b/front/layouts/default.vue
@@ -14,7 +14,7 @@
       <app-bottom-toolbar />
     </template>
 
-    <profile-picker-float v-if="!appStore.isDesktopLayout" />
+    <profile-picker-float v-if="profileStore.dashboard.isProfileFloatVisible && !appStore.isDesktopLayout" />
     <app-bottom-loading />
   </div>
 </template>
@@ -23,9 +23,11 @@ import { ref } from 'vue';
 
 <script setup>
 import RouteConstants from '~/constants/RouteConstants.js'
+import { useProfileStore } from '~/stores/profileStore'
 
 const device = useDevice()
 const appStore = useAppStore()
+const profileStore = useProfileStore()
 
 const layoutClass = computed(() => {
   return {

--- a/front/pages/settings/ui.vue
+++ b/front/pages/settings/ui.vue
@@ -19,6 +19,7 @@
         <app-boolean v-model="showAnimations" :label="$t('settings.ui.show_animations')" />
 
         <app-boolean v-model="resetFormOnCreate" :label="$t('settings.ui.reset_forms_after_creation')" />
+        <app-boolean v-model="isProfileFloatVisible" :label="$t('settings.ui.is_profile_float_visible')" />
       </van-cell-group>
 
       <app-button-form-save />
@@ -44,6 +45,7 @@ const startingPage = ref(null)
 const language = ref(null)
 const showAnimations = ref(true)
 const resetFormOnCreate = ref(false)
+const isProfileFloatVisible = ref(true)
 
 const syncedSettings = [
   { store: profileStore, path: 'darkTheme', ref: darkTheme },
@@ -51,6 +53,7 @@ const syncedSettings = [
   { store: profileStore, path: 'startingPage', ref: startingPage },
   { store: profileStore, path: 'showAnimations', ref: showAnimations },
   { store: profileStore, path: 'resetFormOnCreate', ref: resetFormOnCreate },
+  { store: profileStore, path: 'dashboard.isProfileFloatVisible', ref: isProfileFloatVisible },
 ]
 
 watchSettingsStore(syncedSettings)

--- a/front/stores/profileStore.js
+++ b/front/stores/profileStore.js
@@ -74,6 +74,7 @@ export const useProfileStore = defineStore('profile', () => {
   const recurringTransactionsEnabled = useLocalStorage('recurringTransactionsEnabled', true)
 
   const dashboard = reactive({
+    isProfileFloatVisible: useLocalStorage('isProfileFloatVisible', true),
     firstDayOfMonth: useLocalStorage('firstDayOfMonth', 1),
     showAccountAmounts: useLocalStorage('showAccountAmounts', true),
     showDecimal: useLocalStorage('showDecimals', false),


### PR DESCRIPTION

This PR adds a new dashboard setting that allows users to hide the floating profile list button introduced in v1.8.0.

### Motivation

The floating profile button is useful for users managing multiple profiles, but for users with a single profile it occupies screen space without providing much value.

This change makes the button optional while preserving the current behavior by default.

### Changes

- Added a new dashboard setting to show/hide the floating profile button.
- The setting is stored in the user's dashboard preferences.
- The floating button is conditionally rendered based on the setting.
- Added English and German translations.

### Default Behavior

The button remains visible by default, so existing users will not notice any behavioral changes unless they explicitly disable it.

### Testing

- Verified that the button is visible by default.
- Verified that disabling the setting hides the button.
- Verified that re-enabling the setting shows the button again.
- Verified that the preference persists after reloading the application.