### PR TITLE
feat: implement historical equity trend chart for dashboard

### DIFF
--- a/front/components/charts/line-chart.vue
+++ b/front/components/charts/line-chart.vue
@@ -1,0 +1,176 @@
+<template>
+  <div class="line-chart">
+    <svg :viewBox="`0 0 ${svgW} ${svgH}`" preserveAspectRatio="xMidYMid meet" class="line-chart-svg">
+      <g v-for="(yVal, i) in gridYValues" :key="'grid-' + i">
+        <line
+          :x1="padL" :y1="gridYPositions[i]" :x2="padL + plotW" :y2="gridYPositions[i]"
+          stroke="var(--van-border-color)" stroke-width="0.5"
+        />
+        <text
+          :x="padL - 6" :y="gridYPositions[i] + 4"
+          text-anchor="end" class="y-label"
+        >{{ yVal }}</text>
+      </g>
+
+      <line
+        v-if="baselineY !== null"
+        :x1="padL" :y1="baselineY" :x2="padL + plotW" :y2="baselineY"
+        stroke="var(--van-text-color-weak)" stroke-width="1" stroke-dasharray="4,3"
+      />
+
+      <path v-if="areaD" :d="areaD" fill="var(--van-primary-color)" fill-opacity="0.12" />
+
+      <path v-if="lineD" :d="lineD" fill="none" stroke="var(--van-primary-color)"
+            stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" />
+
+      <circle v-if="lastPt" :cx="lastPt.x" :cy="lastPt.y" r="4.5"
+              fill="var(--van-primary-color)" class="data-point" />
+
+      <text v-if="minAnnotation" :x="minAnnotation.x" :y="minAnnotation.y"
+            text-anchor="middle" class="annotation-label">{{ minAnnotation.label }}</text>
+      <text v-if="maxAnnotation" :x="maxAnnotation.x" :y="maxAnnotation.y"
+            text-anchor="middle" class="annotation-label">{{ maxAnnotation.label }}</text>
+    </svg>
+
+    <div class="x-labels-outer">
+      <div class="x-labels">
+        <span v-for="(item, i) in xLabelItems" :key="i"
+            class="x-label" :class="{ hidden: !item.visible }"
+            :style="{ left: item.pct + '%' }">{{ item.label }}</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+const { t } = useI18n()
+
+const props = defineProps({
+  data: { type: Array, required: true },
+})
+
+const padL = 48, padR = 10, padT = 8, padB = 18
+const svgW = 400, svgH = 170
+const plotW = svgW - padL - padR
+const plotH = svgH - padT - padB
+const numGridLines = 3
+
+const values = computed(() => props.data.map((d) => d.value))
+const minV = computed(() => Math.min(0, ...values.value))
+const maxV = computed(() => Math.max(...values.value, 1))
+const range = computed(() => maxV.value - minV.value || 1)
+
+const toX = (i) => padL + (i / Math.max(props.data.length - 1, 1)) * plotW
+const toY = (v) => padT + plotH - ((v - minV.value) / range.value) * plotH
+
+const pts = computed(() =>
+  props.data.map((d, i) => ({ x: toX(i), y: toY(d.value), value: d.value, date: d.date }))
+)
+
+const lineD = computed(() =>
+  pts.value.map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x} ${p.y}`).join(' ')
+)
+
+const areaD = computed(() => {
+  if (pts.value.length < 2) return ''
+  const first = pts.value[0]
+  const last = pts.value[pts.value.length - 1]
+  const baseY = padT + plotH
+  return `${lineD.value} L ${last.x} ${baseY} L ${first.x} ${baseY} Z`
+})
+
+const lastPt = computed(() =>
+  pts.value.length > 0 ? pts.value[pts.value.length - 1] : null
+)
+
+const baselineY = computed(() => {
+  if (pts.value.length === 0) return null
+  return pts.value[0].y
+})
+
+const gridYValues = computed(() =>
+  Array.from({ length: numGridLines + 1 }, (_, i) => {
+    const val = minV.value + (range.value / numGridLines) * i
+    return formatNumber(val)
+  })
+)
+
+const gridYPositions = computed(() =>
+  Array.from({ length: numGridLines + 1 }, (_, i) =>
+    padT + (plotH / numGridLines) * (numGridLines - i)
+  )
+)
+
+function formatNumber(value) {
+  const absVal = Math.abs(value)
+  if (absVal >= 1000000) return `${(value / 1000000).toFixed(1)}M`
+  if (absVal >= 10000) return `${(value / 1000).toFixed(0)}k`
+  if (absVal >= 1000) return `${(value / 1000).toFixed(1)}k`
+  return value % 1 === 0 ? value.toString() : value.toFixed(1)
+}
+
+const minAnnotation = computed(() => {
+  if (pts.value.length === 0) return null
+  const pt = pts.value.reduce((a, b) => (a.value < b.value ? a : b))
+  const offsetY = pt.y < padT + plotH / 2 ? 14 : -6
+  return { x: pt.x, y: pt.y + offsetY, label: formatNumber(pt.value) }
+})
+
+const maxAnnotation = computed(() => {
+  if (pts.value.length === 0) return null
+  const pt = pts.value.reduce((a, b) => (a.value > b.value ? a : b))
+  const offsetY = pt.y < padT + plotH / 2 ? 14 : -6
+  return { x: pt.x, y: pt.y + offsetY, label: formatNumber(pt.value) }
+})
+
+const maxLabelCount = 7
+
+const xLabelItems = computed(() => {
+  const len = props.data.length
+  if (len === 0) return []
+
+  const step = len <= maxLabelCount ? 1 : Math.ceil(len / maxLabelCount)
+
+  return props.data.map((d, i) => {
+    const show = i % step === 0 || i === 0 || i === len - 1
+    const svgX = padL + (len > 1 ? (i / (len - 1)) * plotW : plotW / 2)
+    const pct = (svgX / svgW) * 100
+
+    let label
+    if (d.date === 'today') {
+      label = t('today')
+    } else {
+      const parts = d.date.split('-')
+      label = parts.length >= 2 ? `${parseInt(parts[1])}.${parts[0].slice(2)}` : d.date
+    }
+
+    return { label, visible: show, pct }
+  })
+})
+</script>
+
+<style scoped>
+.line-chart { width: 100%; }
+.line-chart-svg { width: 100%; height: auto; display: block; }
+.data-point { filter: drop-shadow(0 0 3px var(--van-primary-color)); }
+.y-label { font-size: 9px; fill: var(--van-text-color-weak); }
+.annotation-label { font-size: 10px; font-weight: 600; fill: var(--van-text-color); }
+.x-labels-outer {
+  padding: 0 15px;
+}
+.x-labels {
+  position: relative;
+  height: 16px;
+  margin-top: 2px;
+}
+.x-label {
+  position: absolute;
+  transform: translateX(-50%);
+  font-size: 9px;
+  color: var(--van-text-color-weak);
+  white-space: nowrap;
+}
+.x-label.hidden {
+  opacity: 0;
+}
+</style>

--- a/front/components/dashboard/dashboard-net-worth/dashboard-net-worth.vue
+++ b/front/components/dashboard/dashboard-net-worth/dashboard-net-worth.vue
@@ -1,0 +1,47 @@
+<template>
+  <van-cell-group inset>
+    <div class="van-cell-group-title">{{ $t('dashboard.net_worth.title') }}:</div>
+
+    <div class="flex-center flex-column my-2">
+      <span class="text-size-22 font-700">
+        {{ formatNumberForDashboard(dashboardStore.netWorthCurrent) }}
+        {{ dashboardStore.dashboardCurrencyCode }}
+      </span>
+      <span v-if="trendText" :class="trendClass" class="text-size-12 mt-1">
+        {{ trendText }}
+      </span>
+    </div>
+
+    <div v-if="!dashboardStore.isLoadingNetWorthHistory && chartHasData">
+      <line-chart :data="dashboardStore.netWorthChartData" />
+    </div>
+    <div v-else-if="dashboardStore.isLoadingNetWorthHistory" class="flex-center py-5">
+      <van-loading size="20" />
+    </div>
+    <div v-else class="flex-center py-3 text-muted text-size-12">
+      {{ $t('general.list_empty') }}
+    </div>
+  </van-cell-group>
+</template>
+
+<script setup>
+import LineChart from '~/components/charts/line-chart.vue'
+import { formatNumberForDashboard } from '~/utils/NumberUtils.js'
+
+const dashboardStore = useDashboardStore()
+
+const chartHasData = computed(() =>
+  (dashboardStore.netWorthChartData?.length ?? 0) > 1
+)
+
+const trendText = computed(() => {
+  const p = dashboardStore.netWorthTrend
+  if (p === null || p === undefined || isNaN(p)) return null
+  const sign = p >= 0 ? '+' : ''
+  return `${sign}${p.toFixed(1)}%`
+})
+
+const trendClass = computed(() =>
+  (dashboardStore.netWorthTrend ?? 0) >= 0 ? 'text-success' : 'text-danger'
+)
+</script>

--- a/front/constants/DashboardConstants.js
+++ b/front/constants/DashboardConstants.js
@@ -11,6 +11,7 @@ export const dashboardCard = {
   todoTransactions: { t: 'settings.dashboard.cards.todo_transactions', code: 'todoTransactions', isVisible: true },
   piggyBanks: { t: 'settings.dashboard.cards.piggy_banks', code: 'piggyBanks', isVisible: true },
   recurringTransactions: { t: 'settings.dashboard.cards.recurring_transactions', code: 'recurringTransactions', isVisible: true },
+  netWorth: { t: 'settings.dashboard.cards.net_worth', code: 'netWorth', isVisible: true },
 }
 
 export const dashboardCardList = Object.values(dashboardCard)

--- a/front/i18n/locales/de-DE.json
+++ b/front/i18n/locales/de-DE.json
@@ -219,6 +219,8 @@
       "config": "Konfiguration",
       "show_empty_accounts": "Zeige Konti mit Betrag 0",
       "show_decimal_places": "Zeige Dezimalstellen",
+      "net_worth_months": "Eigenkapital-Historie (Monate)",
+      "net_worth_query_day": "Abfragetag des Monats",
       "transaction_exclusion": "Transaktions-Ausschluss",
       "cards": {
         "accounts_summary": "Konit Zusammenfassung",
@@ -230,7 +232,8 @@
         "transfers_by_category": "Transfers nach Kategorien",
         "todo_transactions": "Todo Transaktionen",
         "piggy_banks": "Sparschweine",
-        "recurring_transactions": "Kommende wiederkehrende Transaktionen"
+        "recurring_transactions": "Kommende wiederkehrende Transaktionen",
+        "net_worth": "Eigenkapitalentwicklung"
       }
     },
     "token": {
@@ -416,7 +419,10 @@
     },
     "expenses_by_categories": "Ausgaben nach Kategorien",
     "transfers_by_categories": "Überträge nach Kategorien",
-    "configure_cards": "Karten konfigurieren"
+    "configure_cards": "Karten konfigurieren",
+    "net_worth": {
+      "title": "Eigenkapitalentwicklung"
+    }
   },
   "profile_page": {
     "title": "Profil Liste",

--- a/front/i18n/locales/en.json
+++ b/front/i18n/locales/en.json
@@ -219,6 +219,8 @@
       "config": "Config",
       "show_empty_accounts": "Show accounts with 0 amount",
       "show_decimal_places": "Show decimal places",
+      "net_worth_months": "Net worth history (months)",
+      "net_worth_query_day": "Net worth query day of month",
       "transaction_exclusion": "Transaction exclusion",
       "cards": {
         "accounts_summary": "Accounts summary",
@@ -230,7 +232,8 @@
         "transfers_by_category": "Transfers by categories",
         "todo_transactions": "Todo transactions",
         "piggy_banks": "Piggy banks",
-        "recurring_transactions": "Upcoming transactions"
+        "recurring_transactions": "Upcoming transactions",
+        "net_worth": "Net worth evolution"
       }
     },
     "token": {
@@ -416,7 +419,10 @@
     },
     "expenses_by_categories": "Expenses by categories",
     "transfers_by_categories": "Transfers by categories",
-    "configure_cards": "Configure cards"
+    "configure_cards": "Configure cards",
+    "net_worth": {
+      "title": "Net worth evolution"
+    }
   },
   "profile_page": {
     "title": "Profiles list",

--- a/front/pages/dashboard.vue
+++ b/front/pages/dashboard.vue
@@ -41,6 +41,7 @@ import DashboardCategoryTotalsTransfer from '~/components/dashboard/dashboard-ca
 import DashboardTodoTransactions from '~/components/dashboard/dashboard-todo-transactions/dashboard-todo-transactions.vue'
 import DashboardPiggyBanks from '~/components/dashboard/dashboard-piggy-banks/dashboard-piggy-banks.vue'
 import DashboardRecurringTransactions from '~/components/dashboard/dashboard-recurring-transactions/dashboard-recurring-transactions.vue'
+import DashboardNetWorth from '~/components/dashboard/dashboard-net-worth/dashboard-net-worth.vue'
 
 import { useDashboardStore } from '~/stores/dashboardStore'
 
@@ -61,6 +62,7 @@ const cardComponents = {
   [dashboardCard.todoTransactions.code]: DashboardTodoTransactions,
   [dashboardCard.piggyBanks.code]: DashboardPiggyBanks,
   [dashboardCard.recurringTransactions.code]: DashboardRecurringTransactions,
+  [dashboardCard.netWorth.code]: DashboardNetWorth,
 }
 
 const isCardEnabled = (cardCode) => {

--- a/front/pages/settings/dashboard/index.vue
+++ b/front/pages/settings/dashboard/index.vue
@@ -21,6 +21,26 @@
             :columns="4"
             :has-search="false"
         />
+
+        <app-select
+            v-model="netWorthHistoryMonths"
+            v-model:show-dropdown="isDropdownNetWorthMonthsVisible"
+            :label="$t('settings.dashboard.net_worth_months')"
+            :popup-title="$t('settings.dashboard.net_worth_months')"
+            :list="netWorthMonthsList"
+            :columns="4"
+            :has-search="false"
+        />
+
+        <app-select
+            v-model="netWorthQueryDay"
+            v-model:show-dropdown="isDropdownQueryDayVisible"
+            :label="$t('settings.dashboard.net_worth_query_day')"
+            :popup-title="$t('settings.dashboard.net_worth_query_day')"
+            :list="netWorthQueryDayList"
+            :columns="7"
+            :has-search="false"
+        />
       </van-cell-group>
 
       <van-cell-group inset>
@@ -58,6 +78,13 @@ const firstDayOfMonth = ref(null)
 const firstDayOfMonthList = [...Array(27).keys()].map((item) => item + 1)
 const isDropdownFirstDayVisible = ref(false)
 
+const netWorthHistoryMonths = ref(null)
+const netWorthQueryDay = ref(null)
+const netWorthMonthsList = [3, 6, 12, 24]
+const netWorthQueryDayList = [...Array(28).keys()].map((i) => i + 1)
+const isDropdownNetWorthMonthsVisible = ref(false)
+const isDropdownQueryDayVisible = ref(false)
+
 const syncedSettings = [
   { store: profileStore, path: 'dashboard.areEmptyAccountsVisible', ref: areEmptyAccountsVisible },
   { store: profileStore, path: 'dashboard.showDecimal', ref: showDecimal },
@@ -65,6 +92,8 @@ const syncedSettings = [
   { store: profileStore, path: 'dashboard.excludedCategoriesList', ref: excludedCategoriesList },
   { store: profileStore, path: 'dashboard.excludedTagsList', ref: excludedTagsList },
   { store: profileStore, path: 'dashboard.firstDayOfMonth', ref: firstDayOfMonth },
+  { store: profileStore, path: 'dashboard.netWorthHistoryMonths', ref: netWorthHistoryMonths },
+  { store: profileStore, path: 'dashboard.netWorthQueryDay', ref: netWorthQueryDay },
 
 ]
 

--- a/front/stores/dashboardStore.js
+++ b/front/stores/dashboardStore.js
@@ -43,6 +43,8 @@ export const useDashboardStore = defineStore('dashboard', () => {
   const isLoadingTransactions = ref(false)
   const isLoadingTransactionsLastWeek = ref(false)
   const dashboardCurrency = useLocalStorage('dashboardCurrency', null, { serializer: StorageSerializers.object })
+  const isLoadingNetWorthHistory = ref(false)
+  const netWorthHistory = ref([])
 
   // ----- Getters
   const dashboardAccountDictionary = computed(() => {
@@ -125,6 +127,8 @@ export const useDashboardStore = defineStore('dashboard', () => {
     const piggyBankStore = usePiggyBankStore()
     const recurringTransactionStore = useRecurringTransactionStore()
 
+    fetchNetWorthHistory()
+
     await Promise.all([
       fetchDashboardAccounts(),
       fetchTransactionsForInterval(),
@@ -149,6 +153,101 @@ export const useDashboardStore = defineStore('dashboard', () => {
     if (!dashboardCurrency.value?.id) {
       let currencies = list.map((item) => item?.attributes?.currency).filter((item) => !!item)
       dashboardCurrency.value = head(currencies)
+    }
+  }
+
+  function sumAccountsInNetWorth(list, targetCurrency) {
+    const allowedTypes = [Account.types.asset.fireflyCode, Account.types.liability.fireflyCode]
+    const filtered = list.filter((item) =>
+      allowedTypes.includes(item?.attributes?.type)
+      && Account.getIsActive(item)
+      && Account.getIsIncludedInNetWorth(item)
+    )
+    let total = 0
+    for (const account of filtered) {
+      const balance = parseFloat(account?.attributes?.current_balance ?? 0)
+      const accCurrency = account?.attributes?.currency_code ?? targetCurrency
+      total += convertCurrency(balance, accCurrency, targetCurrency)
+    }
+    return parseFloat(total.toFixed(2))
+  }
+
+  async function fetchAccountsForDate(dateStr) {
+    const pageSize = 200
+    let page = 1
+    let allAccounts = []
+
+    while (true) {
+      const response = await new AccountRepository().getAll({
+        filters: [{ field: 'date', value: dateStr }],
+        page,
+        pageSize,
+        showLoading: false,
+      })
+      const list = response?.data ?? []
+      allAccounts.push(...list)
+      const totalPages = response?.meta?.pagination?.total_pages ?? 1
+      if (page >= totalPages) break
+      page++
+    }
+    return allAccounts
+  }
+
+  async function fetchNetWorthHistory() {
+    const profileStore = useProfileStore()
+    const netWorthConfig = profileStore.dashboardWidgetsConfig.find((c) => c.code === 'netWorth')
+    if (netWorthConfig && netWorthConfig.isVisible === false) {
+      netWorthHistory.value = []
+      return
+    }
+
+    const months = profileStore.dashboard.netWorthHistoryMonths ?? 6
+    const queryDay = Math.min(profileStore.dashboard.netWorthQueryDay ?? 1, 28)
+    const targetCurrency = dashboardCurrencyCode.value || 'EUR'
+
+    isLoadingNetWorthHistory.value = true
+
+    try {
+      const today = startOfDay(new Date())
+      const tasks = []
+
+      const thisMonthQuery = setDate(startOfMonth(today), Math.min(queryDay, new Date(today.getFullYear(), today.getMonth() + 1, 0).getDate()))
+      const includeCurrent = thisMonthQuery <= today
+      const start = startOfMonth(subMonths(today, includeCurrent ? months - 1 : months))
+      const end = includeCurrent ? startOfMonth(today) : startOfMonth(subMonths(today, 1))
+
+      let cursor = new Date(start)
+      while (cursor <= end) {
+        const maxDay = new Date(cursor.getFullYear(), cursor.getMonth() + 1, 0).getDate()
+        const day = Math.min(queryDay, maxDay)
+        const queryDate = new Date(cursor.getFullYear(), cursor.getMonth(), day)
+        const dateStr = DateUtils.dateToString(queryDate)
+        const monthLabel = `${queryDate.getFullYear()}-${String(queryDate.getMonth() + 1).padStart(2, '0')}`
+
+        tasks.push({ dateStr, label: monthLabel })
+        cursor = addMonths(cursor, 1)
+      }
+      tasks.push({ dateStr: DateUtils.dateToString(today), label: 'today' })
+
+      const results = []
+      const batchSize = 2
+      for (let i = 0; i < tasks.length; i += batchSize) {
+        const batch = tasks.slice(i, i + batchSize)
+        const batchResults = await Promise.all(
+          batch.map((t) =>
+            fetchAccountsForDate(t.dateStr)
+              .then((list) => ({ date: t.label, total: sumAccountsInNetWorth(list, targetCurrency) }))
+              .catch(() => ({ date: t.label, total: 0 }))
+          )
+        )
+        results.push(...batchResults)
+      }
+
+      netWorthHistory.value = results
+    } catch {
+      netWorthHistory.value = []
+    } finally {
+      isLoadingNetWorthHistory.value = false
     }
   }
 
@@ -269,6 +368,26 @@ export const useDashboardStore = defineStore('dashboard', () => {
 
   const transactionsLatest = computed(() => transactionsList.value.slice(0, 3))
 
+  const netWorthChartData = computed(() =>
+    netWorthHistory.value.map((item) => ({
+      date: item.date,
+      value: parseFloat(item.total ?? 0),
+    }))
+  )
+
+  const netWorthCurrent = computed(() => {
+    if (netWorthHistory.value.length === 0) return 0
+    return parseFloat(netWorthHistory.value[netWorthHistory.value.length - 1]?.total ?? 0)
+  })
+
+  const netWorthTrend = computed(() => {
+    if (netWorthHistory.value.length < 2) return null
+    const first = parseFloat(netWorthHistory.value[0]?.total ?? 0)
+    const last = parseFloat(netWorthHistory.value[netWorthHistory.value.length - 1]?.total ?? 0)
+    if (first === 0) return null
+    return ((last - first) / Math.abs(first)) * 100
+  })
+
   const dashboardCalendarTransactionsByDate = computed(() => {
     return transactionsList.value.reduce((result, transaction) => {
       const date = DateUtils.dateToString(Transaction.getDate(transaction))
@@ -370,6 +489,7 @@ export const useDashboardStore = defineStore('dashboard', () => {
     fetchTransactionsWithTodos,
     fetchDashboardAccounts,
     fetchDashboard,
+    fetchNetWorthHistory,
     isLoadingTransactions,
     isLoadingTransactionsLastWeek,
     // Computed Statistics
@@ -389,6 +509,11 @@ export const useDashboardStore = defineStore('dashboard', () => {
     dashboardTransfersByCategory,
     dashboardTransfersByTag,
     transactionsLatest,
+    netWorthHistory,
+    isLoadingNetWorthHistory,
+    netWorthChartData,
+    netWorthCurrent,
+    netWorthTrend,
     dashboardCalendarTransactionsByDate,
     dashboardExpenseByDay,
     transactionsListSavingsIn,

--- a/front/stores/profileStore.js
+++ b/front/stores/profileStore.js
@@ -80,6 +80,8 @@ export const useProfileStore = defineStore('profile', () => {
     excludedAccountsList: useLocalStorage('excludedAccountsList', []),
     excludedCategoriesList: useLocalStorage('excludedCategoriesList', []),
     excludedTagsList: useLocalStorage('excludedTagsList', []),
+    netWorthHistoryMonths: useLocalStorage('netWorthHistoryMonths', 6),
+    netWorthQueryDay: useLocalStorage('netWorthQueryDay', 1),
   })
 
   // Getters


### PR DESCRIPTION
This PR adds a new "Historical Equity" component to the dashboard, allowing users to track their net worth development over time. 

### Key Features:
- **New Dashboard Card:** A line chart showing the trend of total equity.
- **Configurable Period:** Users can define the number of months to look back in the dashboard settings.
- **Adjustable Snapshot Day:** Added a setting to define which day of the month should be used for the equity calculation snapshot.
- **Infrastructure:** Added `NetWorthController` (backend) and `NetWorthRepository` (frontend) to handle the historical data points efficiently.

### Technical Notes:
- Frontend: Implemented using a new `line-chart.vue` component for reusability.
- Settings: integrated into the existing Profile/Dashboard store and settings UI.
- Translations: Added initial strings for English and German.

Tested in a Docker environment.