### PR TITLE
feat: add optional net amount mode for dashboard charts

### DIFF
--- a/front/components/dashboard/dashboard-category-totals-expense/dashboard-category-totals-expense.vue
+++ b/front/components/dashboard/dashboard-category-totals-expense/dashboard-category-totals-expense.vue
@@ -36,13 +36,15 @@ import { useActionSheet } from '~/composables/useActionSheet.js'
 
 import { useCategoryStore } from '~/stores/categoryStore'
 import { useDashboardStore } from '~/stores/dashboardStore'
+import { useProfileStore } from '~/stores/profileStore.js'
 
 const categoryStore = useCategoryStore()
 const dashboardStore = useDashboardStore()
+const profileStore = useProfileStore()
 const { t } = useI18n()
 
 const barsList = computed(() => {
-  const dictionary = dashboardStore.dashboardExpensesByCategory
+  const dictionary = profileStore.dashboard.dashboardNetAmountMode ? dashboardStore.dashboardNetByCategory : dashboardStore.dashboardExpensesByCategory
 
   const maxAmount = Math.max(...Object.values(dictionary))
 
@@ -81,12 +83,13 @@ const onGoToTransactions = async (category) => {
   const startDate = DateUtils.dateToString(dashboardStore.dashboardDateStart)
   const endDate = DateUtils.dateToString(dashboardStore.dashboardDateEnd)
   const excludedUrl = getExcludedTransactionUrl()
+  const typeParam = profileStore.dashboard.dashboardNetAmountMode ? '' : `&type=${Transaction.types.expense.code}`
 
   if (!category) {
-    await navigateTo(`${RouteConstants.ROUTE_TRANSACTION_LIST}?without_category=true&date_start=${startDate}&date_end=${endDate}&type=${Transaction.types.expense.code}${excludedUrl}`)
+    await navigateTo(`${RouteConstants.ROUTE_TRANSACTION_LIST}?without_category=true&date_start=${startDate}&date_end=${endDate}${typeParam}${excludedUrl}`)
     return
   }
 
-  await navigateTo(`${RouteConstants.ROUTE_TRANSACTION_LIST}?category_id=${category.id}&date_start=${startDate}&date_end=${endDate}&type=${Transaction.types.expense.code}${excludedUrl}`)
+  await navigateTo(`${RouteConstants.ROUTE_TRANSACTION_LIST}?category_id=${category.id}&date_start=${startDate}&date_end=${endDate}${typeParam}${excludedUrl}`)
 }
 </script>

--- a/front/components/dashboard/dashboard-tag-totals-expense/dashboard-tag-totals-expense.vue
+++ b/front/components/dashboard/dashboard-tag-totals-expense/dashboard-tag-totals-expense.vue
@@ -38,9 +38,11 @@ import Tag from '~/models/Tag.js'
 import TablerIconConstants from '~/constants/TablerIconConstants.js'
 import { getExcludedTransactionUrl } from '~/utils/DashboardUtils.js'
 import { useActionSheet } from '~/composables/useActionSheet.js'
+import { useProfileStore } from '~/stores/profileStore.js'
 
 const dashboardStore = useDashboardStore()
 const tagStore = useTagStore()
+const profileStore = useProfileStore()
 const { t } = useI18n()
 
 const onToggleTagMode = () => {
@@ -50,7 +52,7 @@ const onToggleTagMode = () => {
 const tagModeDisplayName = computed(() => (dashboardStore.tagsWidgetModeOnlyRootTag ? t('dashboard.expenses_by_tags.one_root_tag') : t('dashboard.expenses_by_tags.all_tags')))
 
 const barsList = computed(() => {
-  const tagTotalDictionary = dashboardStore.dashboardExpensesByTag
+  const tagTotalDictionary = profileStore.dashboard.dashboardNetAmountMode ? dashboardStore.dashboardNetByTag : dashboardStore.dashboardExpensesByTag
 
   const maxAmount = Math.max(...Object.values(tagTotalDictionary))
 
@@ -87,12 +89,13 @@ const onGoToTransactions = async (tag) => {
   const startDate = DateUtils.dateToString(dashboardStore.dashboardDateStart)
   const endDate = DateUtils.dateToString(dashboardStore.dashboardDateEnd)
   const excludedUrl = getExcludedTransactionUrl()
+  const typeParam = profileStore.dashboard.dashboardNetAmountMode ? '' : `&type=${Transaction.types.expense.code}`
 
   if (!tag) {
-    await navigateTo(`${RouteConstants.ROUTE_TRANSACTION_LIST}?without_tag=true&date_start=${startDate}&date_end=${endDate}&type=${Transaction.types.expense.code}${excludedUrl}`)
+    await navigateTo(`${RouteConstants.ROUTE_TRANSACTION_LIST}?without_tag=true&date_start=${startDate}&date_end=${endDate}${typeParam}${excludedUrl}`)
     return
   }
 
-  await navigateTo(`${RouteConstants.ROUTE_TRANSACTION_LIST}?tag_id=${tag.id}&date_start=${startDate}&date_end=${endDate}&type=${Transaction.types.expense.code}${excludedUrl}`)
+  await navigateTo(`${RouteConstants.ROUTE_TRANSACTION_LIST}?tag_id=${tag.id}&date_start=${startDate}&date_end=${endDate}${typeParam}${excludedUrl}`)
 }
 </script>

--- a/front/i18n/locales/de-DE.json
+++ b/front/i18n/locales/de-DE.json
@@ -219,6 +219,7 @@
       "config": "Konfiguration",
       "show_empty_accounts": "Zeige Konti mit Betrag 0",
       "show_decimal_places": "Zeige Dezimalstellen",
+      "net_amount_mode": "Netto-Modus (Ausgaben minus Einnahmen)",
       "transaction_exclusion": "Transaktions-Ausschluss",
       "cards": {
         "accounts_summary": "Konit Zusammenfassung",

--- a/front/i18n/locales/en.json
+++ b/front/i18n/locales/en.json
@@ -219,6 +219,7 @@
       "config": "Config",
       "show_empty_accounts": "Show accounts with 0 amount",
       "show_decimal_places": "Show decimal places",
+      "net_amount_mode": "Net amount mode (expenses minus income)",
       "transaction_exclusion": "Transaction exclusion",
       "cards": {
         "accounts_summary": "Accounts summary",

--- a/front/pages/settings/dashboard/index.vue
+++ b/front/pages/settings/dashboard/index.vue
@@ -11,6 +11,7 @@
         <div class="van-cell-group-title mb-0">{{ $t('settings.dashboard.config') }}:</div>
         <app-boolean v-model="areEmptyAccountsVisible" :label="$t('settings.dashboard.show_empty_accounts')" />
         <app-boolean v-model="showDecimal" :label="$t('settings.dashboard.show_decimal_places')" />
+        <app-boolean v-model="dashboardNetAmountMode" :label="$t('settings.dashboard.net_amount_mode')" />
 
         <app-select
             v-model="firstDayOfMonth"
@@ -53,6 +54,7 @@ const showDecimal = ref(false)
 const excludedAccountsList = ref([])
 const excludedCategoriesList = ref([])
 const excludedTagsList = ref([])
+const dashboardNetAmountMode = ref(false)
 
 const firstDayOfMonth = ref(null)
 const firstDayOfMonthList = [...Array(27).keys()].map((item) => item + 1)
@@ -64,6 +66,7 @@ const syncedSettings = [
   { store: profileStore, path: 'dashboard.excludedAccountsList', ref: excludedAccountsList },
   { store: profileStore, path: 'dashboard.excludedCategoriesList', ref: excludedCategoriesList },
   { store: profileStore, path: 'dashboard.excludedTagsList', ref: excludedTagsList },
+  { store: profileStore, path: 'dashboard.dashboardNetAmountMode', ref: dashboardNetAmountMode },
   { store: profileStore, path: 'dashboard.firstDayOfMonth', ref: firstDayOfMonth },
 
 ]

--- a/front/stores/dashboardStore.js
+++ b/front/stores/dashboardStore.js
@@ -241,6 +241,56 @@ export const useDashboardStore = defineStore('dashboard', () => {
     }, {})
   })
 
+  const dashboardNetByCategory = computed(() => {
+    const incomeByCategory = transactionsListIncome.value.reduce((result, transaction) => {
+      const splits = Transaction.getSplits(transaction)
+      for (let split of splits) {
+        const categoryId = split.category_id
+        const oldTotal = result[categoryId] ?? 0
+        result[categoryId] = oldTotal + convertCurrency(split.amount, split.currency_code, Currency.getCode(dashboardCurrency.value))
+      }
+      return result
+    }, {})
+
+    const result = {}
+    const allCategoryIds = new Set([...Object.keys(dashboardExpensesByCategory.value), ...Object.keys(incomeByCategory)])
+    for (const categoryId of allCategoryIds) {
+      const expense = dashboardExpensesByCategory.value[categoryId] ?? 0
+      const income = incomeByCategory[categoryId] ?? 0
+      const net = income - expense
+      if (net < 0) {
+        result[categoryId] = Math.abs(net)
+      }
+    }
+    return result
+  })
+
+  const dashboardNetByTag = computed(() => {
+    const incomeByTag = transactionsListIncome.value.reduce((result, transaction) => {
+      let tags = Transaction.getTags(transaction)
+      let rootTag = tags.find((tag) => !tag?.attributes?.parent_id) ?? tags[0]
+      let targetTags = tagsWidgetModeOnlyRootTag.value ? [rootTag] : tags
+      for (let targetTag of targetTags) {
+        let tagId = targetTag?.id ?? 0
+        let oldTotal = result[tagId] ?? 0
+        result[tagId] = oldTotal + convertTransactionAmountToCurrency(transaction, Currency.getCode(dashboardCurrency.value))
+      }
+      return result
+    }, {})
+
+    const result = {}
+    const allTagIds = new Set([...Object.keys(dashboardExpensesByTag.value), ...Object.keys(incomeByTag)])
+    for (const tagId of allTagIds) {
+      const expense = dashboardExpensesByTag.value[tagId] ?? 0
+      const income = incomeByTag[tagId] ?? 0
+      const net = income - expense
+      if (net < 0) {
+        result[tagId] = Math.abs(net)
+      }
+    }
+    return result
+  })
+
   const dashboardTransfersByCategory = computed(() => {
     return transactionsListTransfers.value.reduce((result, transaction) => {
       const splits = Transaction.getSplits(transaction)
@@ -386,6 +436,8 @@ export const useDashboardStore = defineStore('dashboard', () => {
     transactionsListTransfers,
     dashboardExpensesByCategory,
     dashboardExpensesByTag,
+    dashboardNetByCategory,
+    dashboardNetByTag,
     dashboardTransfersByCategory,
     dashboardTransfersByTag,
     transactionsLatest,

--- a/front/stores/profileStore.js
+++ b/front/stores/profileStore.js
@@ -80,6 +80,7 @@ export const useProfileStore = defineStore('profile', () => {
     excludedAccountsList: useLocalStorage('excludedAccountsList', []),
     excludedCategoriesList: useLocalStorage('excludedCategoriesList', []),
     excludedTagsList: useLocalStorage('excludedTagsList', []),
+    dashboardNetAmountMode: useLocalStorage('dashboardNetAmountMode', false),
   })
 
   // Getters


### PR DESCRIPTION
This PR implements the requested "Net amount mode" for dashboard charts as discussed in #293.

### Changes

#### 1. Feature: Optional Net Amount Mode
- Added a new toggle **"Net amount mode (expenses minus income)"** to the Dashboard Settings (stored in `profileStore` via LocalStorage).
- Implemented net amount calculation logic in `dashboardStore.js` for both Categories and Tags.
- **Design Choice:** As discussed, the dashboard remains expense-oriented. The charts will only display categories/tags with a resulting **negative net amount** (net expenses). Positive net amounts (net income) are filtered out to keep the UI consistent and focused on spending.
- Fixed a filtering inconsistency: Clicking on a Category chart bar now correctly redirects to the transaction list without forcing a fixed "expense" filter if Net Mode is active, making it consistent with Tag chart behavior.
- Added i18n strings for English and German.

### Related Issues
Closes #293

### Testing
- Tested locally using the optimized Docker build.
- Verified that the toggle correctly switches chart data.
- Verified that only negative net amounts are displayed in Net Mode.
- Verified that transaction list redirects work as expected for both Categories and Tags.