### PR TITLE
Fix Markdown note contrast in Black theme

### DIFF
--- a/front/assets/styles/theme-dark.css
+++ b/front/assets/styles/theme-dark.css
@@ -239,6 +239,10 @@
     color: var(--van-text-color-4) !important;
 }
 
+.van-theme-dark .transaction-notes-markdown pre {
+    color: inherit;
+}
+
 .van-theme-dark .list-item-title {
     color: var(--van-cell-text-color);
 }

--- a/front/components/list-items/transaction-list-item-desktop.vue
+++ b/front/components/list-items/transaction-list-item-desktop.vue
@@ -13,7 +13,7 @@
           <span class="transaction-desktop-title ellipse-text">{{ description }}</span>
           <app-icon v-if="hasAttachments" :icon="TablerIconConstants.attachment" :size="13" color="#1E88E5" />
         </div>
-        <div v-if="notes" class="transaction-desktop-muted transaction-desktop-notes ellipse-text" v-html="notes" />
+        <div v-if="notes" class="transaction-notes-markdown transaction-desktop-muted transaction-desktop-notes ellipse-text" v-html="notes" />
       </div>
 
       <div class="transaction-desktop-amount text-left line-height-normal">

--- a/front/components/list-items/transaction-list-item.vue
+++ b/front/components/list-items/transaction-list-item.vue
@@ -26,7 +26,7 @@
 
             <div v-if="notes && props.isDetailedMode" class="list-item-subtitle" :style="getStyleForField(transactionListField.notes)">
               <app-icon :icon="TablerIconConstants.fieldText1" :size="20" />
-              <span class="notes-markdown max-2-lines word-break-word" v-html="notes" />
+              <span class="transaction-notes-markdown notes-markdown max-2-lines word-break-word" v-html="notes" />
             </div>
 
             <div v-if="profileStore.tagsEnabled && tags && props.isDetailedMode" class="tags-container" :style="getStyleForField(transactionListField.tags)">

--- a/front/components/transaction/transaction-note-field.vue
+++ b/front/components/transaction/transaction-note-field.vue
@@ -11,7 +11,7 @@
 
       <van-dialog v-model:show="isPreviewVisible" confirm-button-text="OK" :close-on-click-overlay="true" style="top: 50%;">
         <div class="p-20">
-          <div class="app-toolbar-body" style="overflow: auto; max-height: 70vh" v-html="markdown"/>
+          <div class="transaction-notes-markdown app-toolbar-body" style="overflow: auto; max-height: 70vh" v-html="markdown"/>
         </div>
       </van-dialog>
     </template>


### PR DESCRIPTION
## Why

Markdown code blocks in transaction notes use Bootstrap's explicit near-black `<pre>` color, which overrides the inherited light text color in the Black theme. This makes rendered notes difficult to read in transaction lists and the preview dialog.

## What changed

- Added a semantic `transaction-notes-markdown` class to the rendered-note containers used by the mobile list, desktop list, and preview dialog.
- Added a Black-theme-only rule that lets `<pre>` inherit the text color of its note surface.

## Scope boundaries

### Included

- Mobile and desktop transaction-list notes.
- Transaction-note preview rendering.
- Black- and light-theme compatibility.

### Not included

- The textarea editor.
- Markdown parsing or stored note data.
- Global `<pre>` styling outside rendered transaction notes.

## Verification

| Check | Result | Evidence |
| --- | --- | --- |
| `npm run build` | `PASS` | Fresh Nuxt production build completed on the PR head. |
| `git diff upstream/dev...HEAD --check` | `PASS` | No whitespace errors. |
| Browser computed-style fixture | `PASS` | All six desktop/mobile/preview pairs matched their parent color in Black and light themes. |
| `docker build --build-arg APP_VERSION=local --tag firefly-pico:local .` | `PASS` | Image built successfully and the compiled CSS contained the scoped rule. |
| Manual Docker UI verification | `PASS` | The issue author verified the fix in the local image and confirmed the result looks correct. |
| Focused ESLint | `FAIL` | One existing unused-import error and seven existing warnings; identical before and after this change. |
| Focused Prettier check | `FAIL` | The same four touched files are pre-existing formatting failures on `upstream/dev`; this change adds no new files or findings. |

The repository-wide lint command was not rerun on the PR branch because its recorded `upstream/dev` baseline already reports 585 findings; the focused checks above were compared directly with their pre-change results.

## UI evidence

Sanitized before/after screenshots and reproduction details are in #313.

- Mobile: rendered code blocks inherit the detailed-list note color.
- Desktop: rendered code blocks inherit the muted transaction-note color.
- Light theme: the existing dark text color remains unchanged.
- Black theme: rendered code blocks use the light color of their containing surface.

## Compatibility, data, and security

No API, data-shape, migration, authentication, dependency, or secret-handling changes. The override is scoped to rendered transaction-note Markdown in Black theme.

## Related

Closes #313.
