### PR TITLE
Display complete split transaction details

### DIFF
--- a/front/assets/styles/theme-dark.css
+++ b/front/assets/styles/theme-dark.css
@@ -421,6 +421,12 @@
     background: #B71C1C;
 }
 
+.van-theme-dark .transaction-split-summary,
+.van-theme-dark .transaction-split-card,
+.van-theme-dark .transaction-split-attachments {
+    box-shadow: rgba(0, 0, 0, 0.35) 0 8px 24px;
+}
+
 .van-theme-dark .assistant-tag {
     box-shadow: 0 2px 6px 0px rgba(0, 0, 0, 0.65);
 }

--- a/front/assets/styles/theme-white.css
+++ b/front/assets/styles/theme-white.css
@@ -1038,6 +1038,193 @@ svg {
     line-height: 16px;
 }
 
+.transaction-split-view {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding-bottom: 20px;
+}
+
+.transaction-split-summary,
+.transaction-split-card,
+.transaction-split-attachments {
+    overflow: hidden;
+    border: 1px solid var(--van-border-color);
+    border-radius: 10px;
+    box-shadow: rgba(149, 157, 165, 0.2) 0 8px 24px;
+}
+
+.transaction-split-summary-cell {
+    padding: 16px;
+}
+
+.transaction-split-summary-cell .van-cell__title,
+.transaction-split-card-header .van-cell__title {
+    min-width: 0;
+}
+
+.transaction-split-summary-cell .van-cell__value,
+.transaction-split-card-header .van-cell__value {
+    flex: 0 0 auto;
+    margin-left: 14px;
+}
+
+.transaction-split-summary-heading {
+    display: flex;
+    align-items: flex-start;
+    flex-wrap: wrap;
+    gap: 7px;
+}
+
+.transaction-split-group-title {
+    flex: 1 1 190px;
+    color: var(--van-text-color);
+    font-size: 15px;
+    font-weight: 700;
+    line-height: 1.35;
+}
+
+.transaction-split-summary-meta {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-top: 7px;
+    color: var(--van-text-color-3);
+    font-size: 11px;
+    line-height: 1.3;
+}
+
+.transaction-split-total {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 4px;
+}
+
+.transaction-split-total-label {
+    color: var(--van-text-color-3);
+    font-size: 10px;
+    font-weight: 600;
+    line-height: 1.2;
+    text-transform: uppercase;
+}
+
+.transaction-split-total-value,
+.transaction-split-card-amount {
+    width: fit-content;
+    padding: 3px 10px;
+    border-radius: 25px;
+    font-size: 13px;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    line-height: 1.3;
+    white-space: nowrap;
+}
+
+.transaction-split-list {
+    display: grid;
+    gap: 12px;
+    margin: 0 16px;
+}
+
+.transaction-split-card {
+    height: fit-content;
+    margin: 0 !important;
+}
+
+.transaction-split-card-header {
+    background: var(--van-background-2);
+}
+
+.transaction-split-card-position {
+    color: var(--van-text-color-3);
+    font-size: 10px;
+    font-weight: 700;
+    line-height: 1.2;
+}
+
+.transaction-split-card-title {
+    margin-top: 3px;
+    color: var(--van-text-color);
+    font-size: 14px;
+    font-weight: 700;
+    line-height: 1.35;
+}
+
+.transaction-split-foreign-amount {
+    margin-top: 4px;
+    color: var(--van-text-color-3);
+    font-size: 11px;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+}
+
+.transaction-split-fallback-badge {
+    display: inline-flex;
+    align-items: center;
+    min-width: 0;
+    gap: 4px;
+    padding: 2px 6px;
+    border: 1px dashed var(--van-border-color);
+    border-radius: 6px;
+    background: var(--van-background-2);
+    color: var(--van-text-color-2);
+    font-size: 12px;
+}
+
+.transaction-split-detail-row .van-cell__title {
+    flex: 0 0 112px;
+}
+
+.transaction-split-detail-row .van-cell__value {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    overflow: visible;
+}
+
+.transaction-split-detail-label {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    color: var(--van-text-color-2);
+    font-size: 12px;
+}
+
+.transaction-split-detail-text {
+    color: var(--van-text-color);
+    font-size: 12px;
+    line-height: 1.35;
+    text-align: right;
+}
+
+.transaction-split-tags {
+    display: flex;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+    gap: 4px;
+}
+
+.transaction-split-notes-row .van-cell__title {
+    flex: 1;
+}
+
+.transaction-split-notes {
+    margin-top: 7px;
+    color: var(--van-text-color);
+    font-size: 12px;
+    line-height: 1.45;
+    white-space: pre-wrap;
+}
+
+.transaction-split-attachments {
+    margin-top: 0;
+}
+
+.transaction-split-view-desktop .transaction-split-list {
+    grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+}
+
 .day-frame {
     display: flex;
     flex-direction: column;

--- a/front/components/transaction/TransactionForm.vue
+++ b/front/components/transaction/TransactionForm.vue
@@ -1,12 +1,10 @@
 <template>
-  <transaction-type-tabs v-model="type" class="mx-3 mt-1 mb-1" />
+  <transaction-split-view v-if="isSplitTransaction" :transaction="item" />
 
-  <van-form ref="formRef" :disabled="isFormDisabled" :name="props.formName" class="transaction-form-group" @submit="emit('submit')" @failed="emit('failed', $event)">
+  <transaction-type-tabs v-if="!isSplitTransaction" v-model="type" class="mx-3 mt-1 mb-1" />
+
+  <van-form v-if="!isSplitTransaction" ref="formRef" :disabled="isFormDisabled" :name="props.formName" class="transaction-form-group" @submit="emit('submit')" @failed="emit('failed', $event)">
     <van-cell-group inset class="dynamic-masonry display-flex-column">
-      <div v-if="isSplitTransaction" class="display-flex ml-3 mt-3">
-        <transaction-split-badge />
-      </div>
-
       <transaction-amount-field
         v-model:amount="amount"
         v-model:amount-foreign="amountForeign"
@@ -98,9 +96,9 @@
 import RouteConstants from '~/constants/RouteConstants'
 import Transaction from '~/models/Transaction'
 import TablerIconConstants from '~/constants/TablerIconConstants'
-import TransactionSplitBadge from '~/components/transaction/transaction-split-badge.vue'
 import TransactionAttachmentsList from '~/components/transaction/transaction-attachements/transaction-attachments-list.vue'
 import TransactionNoteField from '~/components/transaction/transaction-note-field.vue'
+import TransactionSplitView from '~/components/transaction/transaction-split-view.vue'
 import { transactionFormField, transactionExtraDateFieldList } from '~/constants/TransactionConstants.js'
 import { rule } from '~/utils/ValidationUtils.js'
 import { useTransactionForm } from '~/composables/useTransactionForm.js'

--- a/front/components/transaction/transaction-attachements/transaction-attachment.vue
+++ b/front/components/transaction/transaction-attachements/transaction-attachment.vue
@@ -8,16 +8,22 @@
 <script setup>
 import { IconPhoto } from '@tabler/icons-vue'
 
-import { get, head } from 'lodash-es'
+import { get } from 'lodash-es'
 import { trimString } from '~/utils/StringUtils.js'
 import { downloadFileFromUrl, showImageFromUrl } from '~/utils/AttachmentUtils.js'
-import { onLongPress } from '@vueuse/core'
 import { useTap, useTapEvent } from '~/composables/useTap.js'
 import { useActionSheet } from '~/composables/useActionSheet.js'
 import AttachmentRepository from '~/repository/AttachmentRepository.js'
 
 const props = defineProps({
-  value: {},
+  value: {
+    type: Object,
+    default: () => ({}),
+  },
+  readOnly: {
+    type: Boolean,
+    default: false,
+  },
 })
 
 const emits = defineEmits(['result', 'isLoading'])
@@ -35,12 +41,21 @@ const tapBinding = useTap(async (event) => {
     case useTapEvent.single:
       emits('isLoading', true)
       try {
-        isImage.value ? await showImageFromUrl(downloadUrl.value) : await downloadFileFromUrl(downloadUrl.value, filename.value)
-      } catch {}
+        if (isImage.value) {
+          await showImageFromUrl(downloadUrl.value)
+        } else {
+          await downloadFileFromUrl(downloadUrl.value, filename.value)
+        }
+      } catch {
+        // Existing attachment downloads fail silently; always clear the loading state below.
+      }
       emits('isLoading', false)
       break
     case useTapEvent.double:
     case useTapEvent.long:
+      if (props.readOnly) {
+        return
+      }
       useActionSheet().show([
         {
           name: t('delete'),

--- a/front/components/transaction/transaction-attachements/transaction-attachments-list.vue
+++ b/front/components/transaction/transaction-attachements/transaction-attachments-list.vue
@@ -8,9 +8,9 @@
     <div class="flex-center-vertical flex-wrap gap-1 mt-2">
       <van-loading v-if="isLoading" />
 
-      <transaction-attachment v-for="item in list" :key="item.id" :value="item" @result="fetchAttachments" @is-loading="onLoadingChange" />
+      <transaction-attachment v-for="item in list" :key="item.id" :value="item" :read-only="readOnly" @result="fetchAttachments" @is-loading="onLoadingChange" />
 
-      <div v-if="!isLoading" class="add-attachment flex-center">
+      <div v-if="!isLoading && !readOnly" class="add-attachment flex-center">
         <icon-plus :size="30" :stroke="0.8" />
         <input type="file" @change="onUpload" >
       </div>
@@ -19,7 +19,7 @@
 </template>
 
 <script setup>
-import { IconSquarePlus, IconPlus } from '@tabler/icons-vue'
+import { IconPlus } from '@tabler/icons-vue'
 import TransactionAttachment from '~/components/transaction/transaction-attachements/transaction-attachment.vue'
 import AttachmentRepository from '~/repository/AttachmentRepository.js'
 import { get, head } from 'lodash-es'
@@ -31,7 +31,14 @@ const isLoading = ref(false)
 const list = ref([])
 
 const props = defineProps({
-  transaction: {},
+  transaction: {
+    type: Object,
+    default: () => ({}),
+  },
+  readOnly: {
+    type: Boolean,
+    default: false,
+  },
 })
 
 const transactionId = computed(() => props.transaction?.id)
@@ -45,9 +52,15 @@ const fetchAttachments = async () => {
   isLoading.value = false
 }
 
-watch(transactionId, (newValue) => {
-  fetchAttachments()
-})
+watch(
+  transactionId,
+  (newValue) => {
+    if (newValue) {
+      fetchAttachments()
+    }
+  },
+  { immediate: true },
+)
 
 const onUpload = async (e) => {
   const file = head(e.target.files ?? [])
@@ -57,5 +70,6 @@ const onUpload = async (e) => {
 }
 
 const onLoadingChange = (value) => {
+  isLoading.value = value
 }
 </script>

--- a/front/components/transaction/transaction-split-view.vue
+++ b/front/components/transaction/transaction-split-view.vue
@@ -1,0 +1,189 @@
+<template>
+  <div class="transaction-split-view" :class="{ 'transaction-split-view-desktop': appStore.isDesktopLayout }">
+    <van-cell-group inset class="transaction-split-summary">
+      <van-cell class="transaction-split-summary-cell">
+        <template #title>
+          <div class="transaction-split-summary-heading">
+            <transaction-split-badge />
+            <div class="transaction-split-group-title word-break-word">{{ groupTitle }}</div>
+          </div>
+          <div class="transaction-split-summary-meta">
+            <span>{{ $t('transaction.split_count', { count: splits.length }) }}</span>
+            <span v-if="dateFormatted">•</span>
+            <span v-if="dateFormatted">{{ dateFormatted }}</span>
+          </div>
+        </template>
+
+        <template #value>
+          <div class="transaction-split-total">
+            <div class="transaction-split-total-label">{{ $t('transaction.total_amount') }}</div>
+            <div v-for="total in totals" :key="total.currencyId ?? total.currencyCode ?? total.currencySymbol" class="transaction-split-total-value" :class="amountClass">
+              {{ formatAmountWithCurrency(total.amount, total.currencySymbol, total.currencyCode) }}
+            </div>
+          </div>
+        </template>
+      </van-cell>
+    </van-cell-group>
+
+    <div class="transaction-split-list" role="list">
+      <van-cell-group v-for="(split, index) in splits" :key="split.transaction_journal_id ?? index" inset class="transaction-split-card" role="listitem">
+        <van-cell class="transaction-split-card-header">
+          <template #title>
+            <div class="transaction-split-card-position">{{ index + 1 }} / {{ splits.length }}</div>
+            <div class="transaction-split-card-title word-break-word" role="heading" aria-level="2">{{ split.description }}</div>
+          </template>
+
+          <template #value>
+            <div class="transaction-split-card-amount" :class="amountClass">
+              {{ formatAmountWithCurrency(split.amount, split.currency_symbol, split.currency_code) }}
+            </div>
+            <div v-if="split.amountForeign ?? split.foreign_amount" class="transaction-split-foreign-amount">
+              {{ formatAmountWithCurrency(split.amountForeign ?? split.foreign_amount, split.foreign_currency_symbol, split.foreign_currency_code) }}
+            </div>
+          </template>
+        </van-cell>
+
+        <van-cell v-if="split.accountSource || split.accountDestination || split.source_name || split.destination_name">
+          <template #title>
+            <div class="account-badges-row">
+              <account-badge v-if="split.accountSource" :value="split.accountSource" />
+              <div v-else-if="split.source_name" class="transaction-split-fallback-badge">
+                <app-icon :icon="TablerIconConstants.account" :size="16" />
+                <span>{{ split.source_name }}</span>
+              </div>
+
+              <app-icon v-if="(split.accountSource || split.source_name) && (split.accountDestination || split.destination_name)" icon="IconArrowNarrowRight" :size="16" class="account-flow-arrow" />
+
+              <account-badge v-if="split.accountDestination" :value="split.accountDestination" />
+              <div v-else-if="split.destination_name" class="transaction-split-fallback-badge">
+                <app-icon :icon="TablerIconConstants.account" :size="16" />
+                <span>{{ split.destination_name }}</span>
+              </div>
+            </div>
+          </template>
+        </van-cell>
+
+        <van-cell v-if="profileStore.categoriesEnabled && (split.category || split.category_name)" class="transaction-split-detail-row">
+          <template #title>
+            <div class="transaction-split-detail-label">
+              <app-icon :icon="TablerIconConstants.category" :size="17" />
+              <span>{{ $t('category') }}</span>
+            </div>
+          </template>
+          <template #value>
+            <category-badge v-if="split.category" :value="split.category" />
+            <span v-else>{{ split.category_name }}</span>
+          </template>
+        </van-cell>
+
+        <van-cell v-if="profileStore.budgetsEnabled && (split.budget || split.budget_name)" class="transaction-split-detail-row">
+          <template #title>
+            <div class="transaction-split-detail-label">
+              <app-icon :icon="TablerIconConstants.budget" :size="17" />
+              <span>{{ $t('budget') }}</span>
+            </div>
+          </template>
+          <template #value>
+            <div class="transaction-split-detail-text">{{ split.budget ? Budget.getDisplayName(split.budget) : split.budget_name }}</div>
+          </template>
+        </van-cell>
+
+        <van-cell v-if="profileStore.tagsEnabled && split.tags?.filter(Boolean).length" class="transaction-split-detail-row">
+          <template #title>
+            <div class="transaction-split-detail-label">
+              <app-icon :icon="TablerIconConstants.tag" :size="17" />
+              <span>{{ $t('tags') }}</span>
+            </div>
+          </template>
+          <template #value>
+            <div class="transaction-split-tags">
+              <tag-badge v-for="tag in split.tags.filter(Boolean)" :key="tag.id" :value="tag" :max-length="30" />
+            </div>
+          </template>
+        </van-cell>
+
+        <van-cell v-if="split.subscription_name ?? split.bill_name" class="transaction-split-detail-row">
+          <template #title>
+            <div class="transaction-split-detail-label">
+              <app-icon :icon="TablerIconConstants.recurringTransaction" :size="17" />
+              <span>{{ $t('transaction.subscription') }}</span>
+            </div>
+          </template>
+          <template #value>
+            <div class="transaction-split-detail-text">{{ split.subscription_name ?? split.bill_name }}</div>
+          </template>
+        </van-cell>
+
+        <van-cell v-for="field in getPopulatedExtraDateFields(split)" :key="field.code" class="transaction-split-detail-row">
+          <template #title>
+            <div class="transaction-split-detail-label">
+              <app-icon :icon="field.icon" :size="17" />
+              <span>{{ $t(field.t) }}</span>
+            </div>
+          </template>
+          <template #value>
+            <div class="transaction-split-detail-text">{{ DateUtils.dateToUI(split[field.code]) }}</div>
+          </template>
+        </van-cell>
+
+        <van-cell v-if="split.notes" class="transaction-split-notes-row">
+          <template #title>
+            <div class="transaction-split-detail-label">
+              <app-icon :icon="TablerIconConstants.fieldText1" :size="17" />
+              <span>{{ $t('notes') }}</span>
+            </div>
+            <div class="transaction-split-notes word-break-word">{{ split.notes }}</div>
+          </template>
+        </van-cell>
+      </van-cell-group>
+    </div>
+
+    <van-cell-group v-if="transaction.id" inset class="transaction-split-attachments">
+      <transaction-attachments-list :transaction="transaction" read-only />
+    </van-cell-group>
+  </div>
+</template>
+
+<script setup>
+import Budget from '~/models/Budget.js'
+import DateUtils from '~/utils/DateUtils.js'
+import TablerIconConstants from '~/constants/TablerIconConstants.js'
+import Transaction from '~/models/Transaction.js'
+import TransactionAttachmentsList from '~/components/transaction/transaction-attachements/transaction-attachments-list.vue'
+import TransactionSplitBadge from '~/components/transaction/transaction-split-badge.vue'
+import { formatAmount } from '~/utils/AmountUtils.js'
+import { getTransactionSplitTotals } from '~/utils/TransactionSplitUtils.js'
+import { transactionExtraDateFieldList } from '~/constants/TransactionConstants.js'
+
+const props = defineProps({
+  transaction: {
+    type: Object,
+    default: () => ({}),
+  },
+})
+
+const appStore = useAppStore()
+const profileStore = useProfileStore()
+const { locale } = useI18n()
+
+const splits = computed(() => Transaction.getSplits(props.transaction))
+const totals = computed(() => getTransactionSplitTotals(props.transaction))
+const groupTitle = computed(() => Transaction.getDescription(props.transaction))
+const dateFormatted = computed(() => {
+  const date = Transaction.getDate(props.transaction)
+  return date ? DateUtils.dateToUIWithTime(date) : null
+})
+
+const amountClass = computed(() => {
+  const typeCode = Transaction.getTypeCode(props.transaction)
+  return {
+    'color-expense': typeCode === Transaction.types.expense.code,
+    'color-income': typeCode === Transaction.types.income.code,
+    'color-transfer': typeCode === Transaction.types.transfer.code,
+  }
+})
+
+const formatAmountWithCurrency = (amount, currencySymbol, currencyCode) => [formatAmount(amount, locale.value), currencySymbol ?? currencyCode].filter(Boolean).join(' ')
+
+const getPopulatedExtraDateFields = (split) => transactionExtraDateFieldList.filter((field) => split[field.code])
+</script>

--- a/front/composables/useTransactionForm.js
+++ b/front/composables/useTransactionForm.js
@@ -133,6 +133,10 @@ export const useTransactionForm = ({ item, itemId, profileStore = useProfileStor
   })
 
   watch(description, (newValue) => {
+    if (isSplitTransaction.value) {
+      return
+    }
+
     newValue = newValue ?? ''
     if (profileStore.lowerCaseTransactionDescription) {
       newValue = newValue.toLowerCase()

--- a/front/i18n/locales/de-DE.json
+++ b/front/i18n/locales/de-DE.json
@@ -81,6 +81,10 @@
   "transaction": {
     "title_list": "Transaktions-Liste",
     "split_transaction": "Transaktion aufteilen",
+    "title_split_details": "Details zur geteilten Transaktion",
+    "split_count": "{count} Aufteilungen",
+    "total_amount": "Gesamtbetrag",
+    "subscription": "Abonnement",
     "assistant": "Assistent",
     "assistant_format": "Format = [template / tag?] [amount?] [description?]",
     "assistant_ramble_title": "Dictate transactions",

--- a/front/i18n/locales/en.json
+++ b/front/i18n/locales/en.json
@@ -81,6 +81,10 @@
   "transaction": {
     "title_list": "Transactions list",
     "split_transaction": "Split transaction",
+    "title_split_details": "Split transaction details",
+    "split_count": "{count} splits",
+    "total_amount": "Total amount",
+    "subscription": "Subscription",
     "assistant": "Assistant",
     "assistant_format": "Format = [template / tag?] [amount?] [description?] [±Nd?]",
     "assistant_ramble_title": "Dictate transactions",

--- a/front/i18n/locales/es-MX.json
+++ b/front/i18n/locales/es-MX.json
@@ -81,6 +81,10 @@
   "transaction": {
     "title_list": "Lista de transacciones",
     "split_transaction": "Dividir transacción",
+    "title_split_details": "Detalles de la transacción dividida",
+    "split_count": "{count} partes",
+    "total_amount": "Importe total",
+    "subscription": "Suscripción",
     "assistant": "Asistente",
     "assistant_format": "Formato = [plantilla / etiqueta?] [monto?] [descripción?]",
     "assistant_ramble_title": "Dictate transactions",

--- a/front/i18n/locales/fr.json
+++ b/front/i18n/locales/fr.json
@@ -81,6 +81,10 @@
   "transaction": {
     "title_list": "Transactions",
     "split_transaction": "Transaction fractionnée",
+    "title_split_details": "Détails de la transaction fractionnée",
+    "split_count": "{count} fractions",
+    "total_amount": "Montant total",
+    "subscription": "Abonnement",
     "assistant": "Assistant",
     "assistant_format": "Format = [modele / etiquette?] [montant?] [description?]",
     "assistant_ramble_title": "Dictate transactions",

--- a/front/i18n/locales/it.json
+++ b/front/i18n/locales/it.json
@@ -81,6 +81,10 @@
   "transaction": {
     "title_list": "Elenco transazioni",
     "split_transaction": "Transazione suddivisa",
+    "title_split_details": "Dettagli transazione suddivisa",
+    "split_count": "{count} suddivisioni",
+    "total_amount": "Importo totale",
+    "subscription": "Abbonamento",
     "assistant": "Assistente",
     "assistant_format": "Formato = [modello / tag?] [importo?] [descrizione?]",
     "assistant_ramble_title": "Dictate transactions",

--- a/front/i18n/locales/ko.json
+++ b/front/i18n/locales/ko.json
@@ -81,6 +81,10 @@
   "transaction": {
     "title_list": "거래 목록",
     "split_transaction": "거래 분할",
+    "title_split_details": "분할 거래 세부 정보",
+    "split_count": "{count}개 분할",
+    "total_amount": "총액",
+    "subscription": "구독",
     "assistant": "어시스턴트",
     "assistant_format": "형식 = [템플릿 / 태그?] [금액?] [설명?] [±N일?]",
     "assistant_ramble_title": "거래 받아쓰기",

--- a/front/i18n/locales/pl.json
+++ b/front/i18n/locales/pl.json
@@ -81,6 +81,10 @@
   "transaction": {
     "title_list": "Lista transakcji",
     "split_transaction": "Podziel transakcję",
+    "title_split_details": "Szczegóły podzielonej transakcji",
+    "split_count": "{count} części",
+    "total_amount": "Łączna kwota",
+    "subscription": "Subskrypcja",
     "assistant": "Asystent",
     "assistant_format": "Format = [wzór / tag?] [kwota?] [opis?]",
     "assistant_ramble_title": "Dictate transactions",

--- a/front/i18n/locales/pt-BR.json
+++ b/front/i18n/locales/pt-BR.json
@@ -81,6 +81,10 @@
   "transaction": {
     "title_list": "Lista de transações",
     "split_transaction": "Dividir transação",
+    "title_split_details": "Detalhes da transação dividida",
+    "split_count": "{count} divisões",
+    "total_amount": "Valor total",
+    "subscription": "Assinatura",
     "assistant": "Assistente",
     "assistant_format": "Formato = [modelo / tag?] [valor?] [descrição?]",
     "assistant_ramble_title": "Dictate transactions",

--- a/front/i18n/locales/ro.json
+++ b/front/i18n/locales/ro.json
@@ -81,6 +81,10 @@
   "transaction": {
     "title_list": "Lista tranzacțiilor",
     "split_transaction": "Împarte tranzacția",
+    "title_split_details": "Detalii tranzacție împărțită",
+    "split_count": "{count} părți",
+    "total_amount": "Sumă totală",
+    "subscription": "Abonament",
     "assistant": "Asistent",
     "assistant_format": "Format = [șablon / etichetă?] [sumă?] [descriere?]",
     "assistant_ramble_title": "Dictate transactions",

--- a/front/i18n/locales/ru-RU.json
+++ b/front/i18n/locales/ru-RU.json
@@ -81,6 +81,10 @@
   "transaction": {
     "title_list": "Список транзакций",
     "split_transaction": "Разделенная транзакция",
+    "title_split_details": "Детали разделённой транзакции",
+    "split_count": "{count} частей",
+    "total_amount": "Общая сумма",
+    "subscription": "Подписка",
     "assistant": "Ассистент",
     "assistant_format": "Формат = [шаблон / тег?] [сумма?] [описание?]",
     "assistant_ramble_title": "Dictate transactions",

--- a/front/i18n/locales/zh-CN.json
+++ b/front/i18n/locales/zh-CN.json
@@ -74,6 +74,10 @@
   "transaction": {
     "title_list": "交易列表",
     "split_transaction": "拆分交易",
+    "title_split_details": "拆分交易详情",
+    "split_count": "{count} 个拆分",
+    "total_amount": "总金额",
+    "subscription": "订阅",
     "assistant": "助手",
     "assistant_format": "格式 = [模板 / 标签?] [金额?] [描述?]",
     "assistant_ramble_title": "Dictate transactions",

--- a/front/models/Transaction.js
+++ b/front/models/Transaction.js
@@ -6,6 +6,7 @@ import Account from '~/models/Account'
 import { get } from 'lodash-es'
 import Currency from '~/models/Currency.js'
 import { formatNumber } from '~/utils/NumberUtils.js'
+import { formatAmountToCurrencyPrecision } from '~/utils/AmountUtils.js'
 
 export default class Transaction extends BaseModel {
   getTransformer() {
@@ -159,7 +160,7 @@ export default class Transaction extends BaseModel {
       return null
     }
     let decimals = Currency.getDecimalPlaces(currency) ?? 2
-    return parseFloat(amount).toFixed(decimals)
+    return formatAmountToCurrencyPrecision(amount, decimals)
   }
 
   static getTransactionTypeForAccounts({ source, destination }) {

--- a/front/pages/transactions/[[id]].vue
+++ b/front/pages/transactions/[[id]].vue
@@ -11,7 +11,7 @@
     <transaction-assistant v-if="!itemId && !isCloning" v-model="assistantText" @change="onAssistant" @keyup.enter="saveItem" />
 
     <transaction-form ref="transactionFormRef" v-model="item" :form-name="formName" @submit="saveItem" @failed="onValidationError">
-      <template #actions="{ isSplitTransaction }">
+      <template #actions>
         <div style="margin: 16px; position: relative">
           <app-button-form-delete v-if="itemId && !isSplitTransaction" class="mt-10" @click="onDelete" />
 
@@ -32,7 +32,7 @@
       </template>
     </transaction-form>
 
-    <app-card-info style="order: 99">
+    <app-card-info v-if="!isSplitTransaction" style="order: 99">
       <app-field-link :label="$t('transaction.configure_fields')" :icon="TablerIconConstants.settings" @click="navigateTo(RouteConstants.ROUTE_SETTINGS_TRANSACTION_FORM_FIELDS)" />
     </app-card-info>
   </div>
@@ -79,10 +79,17 @@ const onCreateClone = async () => {
 }
 
 const isCloning = computed(() => !!get(route.query, 'transaction_id'))
+const isSplitTransaction = computed(() => Transaction.isSplitPayment(item.value))
 
 const { t } = useI18n()
 const title = computed(() => {
-  return isCloning.value ? t('transaction.title_clone_transaction') : itemId.value ? t('transaction.title_edit_transaction') : t('transaction.title_add_transaction')
+  return isCloning.value
+    ? t('transaction.title_clone_transaction')
+    : isSplitTransaction.value
+      ? t('transaction.title_split_details')
+      : itemId.value
+        ? t('transaction.title_edit_transaction')
+        : t('transaction.title_add_transaction')
 })
 
 const toolbar = useToolbar()

--- a/front/tests/TransactionSplitUtils.test.js
+++ b/front/tests/TransactionSplitUtils.test.js
@@ -38,7 +38,7 @@ test('uses transformed currency metadata when raw Firefly fields are unavailable
   assert.deepEqual(totals, [{ amount: '4.75', currencyId: '1', currencyCode: 'USD', currencySymbol: '$', decimalPlaces: 2 }])
 })
 
-test('keeps decimal strings exact across currency display formatting and aggregation', () => {
+test('does not coerce Firefly decimal strings before split aggregation', () => {
   const transformedAmounts = ['9999999999999999.990000000000', '0.010000000000'].map((amount) => formatAmountToCurrencyPrecision(amount, 2))
   const totals = getTransactionSplitTotals(transactionWith(transformedAmounts.map((amount) => ({ amount, currency_code: 'USD', currency_symbol: '$', currency_decimal_places: 2 }))))
 

--- a/front/tests/TransactionSplitUtils.test.js
+++ b/front/tests/TransactionSplitUtils.test.js
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { formatAmountToCurrencyPrecision } from '../utils/AmountUtils.js'
+import { getTransactionSplitTotals } from '../utils/TransactionSplitUtils.js'
+
+const transactionWith = (transactions) => ({ attributes: { transactions } })
+
+test('adds split amounts exactly at the declared currency precision', () => {
+  const totals = getTransactionSplitTotals(
+    transactionWith([
+      { amount: '59.40', currency_id: '1', currency_code: 'USD', currency_symbol: '$', currency_decimal_places: 2 },
+      { amount: '2321.00', currency_id: '1', currency_code: 'USD', currency_symbol: '$', currency_decimal_places: 2 },
+    ]),
+  )
+
+  assert.deepEqual(totals, [{ amount: '2380.40', currencyId: '1', currencyCode: 'USD', currencySymbol: '$', decimalPlaces: 2 }])
+})
+
+test('does not introduce floating point artifacts', () => {
+  const totals = getTransactionSplitTotals(
+    transactionWith([
+      { amount: '0.10', currency_code: 'USD', currency_symbol: '$', currency_decimal_places: 2 },
+      { amount: '0.20', currency_code: 'USD', currency_symbol: '$', currency_decimal_places: 2 },
+    ]),
+  )
+
+  assert.equal(totals[0].amount, '0.30')
+})
+
+test('uses transformed currency metadata when raw Firefly fields are unavailable', () => {
+  const totals = getTransactionSplitTotals(
+    transactionWith([
+      { amount: '3.50', currency: { id: '1', attributes: { code: 'USD', symbol: '$', decimal_places: 2 } } },
+      { amount: '1.25', currency: { id: '1', attributes: { code: 'USD', symbol: '$', decimal_places: 2 } } },
+    ]),
+  )
+
+  assert.deepEqual(totals, [{ amount: '4.75', currencyId: '1', currencyCode: 'USD', currencySymbol: '$', decimalPlaces: 2 }])
+})
+
+test('keeps decimal strings exact across currency display formatting and aggregation', () => {
+  const transformedAmounts = ['9999999999999999.990000000000', '0.010000000000'].map((amount) => formatAmountToCurrencyPrecision(amount, 2))
+  const totals = getTransactionSplitTotals(transactionWith(transformedAmounts.map((amount) => ({ amount, currency_code: 'USD', currency_symbol: '$', currency_decimal_places: 2 }))))
+
+  assert.deepEqual(transformedAmounts, ['9999999999999999.99', '0.01'])
+  assert.equal(totals[0].amount, '10000000000000000.00')
+  assert.equal(formatAmountToCurrencyPrecision('4.025000000000', 2), '4.025')
+})
+
+test('keeps unlike currencies separate in first-seen order', () => {
+  const totals = getTransactionSplitTotals(
+    transactionWith([
+      { amount: '10.00', currency_id: '2', currency_code: 'EUR', currency_symbol: '€', currency_decimal_places: 2 },
+      { amount: '4.25', currency_id: '1', currency_code: 'USD', currency_symbol: '$', currency_decimal_places: 2 },
+      { amount: '2.50', currency_id: '2', currency_code: 'EUR', currency_symbol: '€', currency_decimal_places: 2 },
+    ]),
+  )
+
+  assert.deepEqual(totals, [
+    { amount: '12.50', currencyId: '2', currencyCode: 'EUR', currencySymbol: '€', decimalPlaces: 2 },
+    { amount: '4.25', currencyId: '1', currencyCode: 'USD', currencySymbol: '$', decimalPlaces: 2 },
+  ])
+})
+
+test('supports signed amounts and excludes malformed values from totals', () => {
+  const totals = getTransactionSplitTotals(
+    transactionWith([
+      { amount: '5.125', currency_code: 'USD', currency_decimal_places: 2 },
+      { amount: '-1.100', currency_code: 'USD', currency_decimal_places: 2 },
+      { amount: 'not-an-amount', currency_code: 'USD', currency_decimal_places: 2 },
+    ]),
+  )
+
+  assert.deepEqual(totals, [{ amount: '4.025', currencyId: null, currencyCode: 'USD', currencySymbol: null, decimalPlaces: 3 }])
+})
+
+test('returns no totals when the transaction has no valid split amounts', () => {
+  assert.deepEqual(getTransactionSplitTotals(transactionWith([])), [])
+  assert.deepEqual(getTransactionSplitTotals(transactionWith([{ amount: null, currency_code: 'USD' }])), [])
+})

--- a/front/utils/AmountUtils.js
+++ b/front/utils/AmountUtils.js
@@ -38,3 +38,16 @@ export const formatAmount = (value, locale) => {
   const formatted = integer.replace(/\B(?=(\d{3})+(?!\d))/g, group)
   return fraction === undefined ? formatted : `${formatted}${decimal}${fraction}`
 }
+
+export const formatAmountToCurrencyPrecision = (value, decimalPlaces) => {
+  const match = value?.toString().match(/^([+-]?)(\d+)(?:\.(\d+))?$/)
+  if (!match) {
+    return value?.toString() ?? null
+  }
+
+  const configuredDecimalPlaces = Number.parseInt(decimalPlaces, 10)
+  const fraction = (match[3] ?? '').replace(/0+$/, '')
+  const precision = Math.max(Number.isInteger(configuredDecimalPlaces) ? configuredDecimalPlaces : 0, fraction.length)
+  const formattedFraction = fraction.padEnd(precision, '0')
+  return `${match[1]}${match[2]}${precision ? `.${formattedFraction}` : ''}`
+}

--- a/front/utils/TransactionSplitUtils.js
+++ b/front/utils/TransactionSplitUtils.js
@@ -1,0 +1,75 @@
+const parseAmount = (value) => {
+  const match = value?.toString().match(/^([+-]?)(\d+)(?:\.(\d+))?$/)
+  if (!match) {
+    return null
+  }
+
+  return {
+    isNegative: match[1] === '-',
+    integer: match[2],
+    fraction: match[3] ?? '',
+  }
+}
+
+const getCurrencyValue = (split, rawKey, transformedKey) => split?.[rawKey] ?? split?.currency?.[transformedKey] ?? split?.currency?.attributes?.[transformedKey] ?? null
+
+const getCurrencyKey = (split) => {
+  const currencyId = getCurrencyValue(split, 'currency_id', 'id')
+  const currencyCode = getCurrencyValue(split, 'currency_code', 'code')
+  const currencySymbol = getCurrencyValue(split, 'currency_symbol', 'symbol')
+  return currencyId ? `id:${currencyId}` : currencyCode ? `code:${currencyCode}` : currencySymbol ? `symbol:${currencySymbol}` : 'unknown'
+}
+
+const toMinorUnits = ({ isNegative, integer, fraction }, decimalPlaces) => {
+  const digits = `${integer}${fraction.padEnd(decimalPlaces, '0')}`
+  const value = BigInt(digits)
+  return isNegative ? -value : value
+}
+
+const fromMinorUnits = (value, decimalPlaces) => {
+  const sign = value < 0n ? '-' : ''
+  const digits = (value < 0n ? -value : value).toString().padStart(decimalPlaces + 1, '0')
+  if (decimalPlaces === 0) {
+    return `${sign}${digits}`
+  }
+
+  return `${sign}${digits.slice(0, -decimalPlaces)}.${digits.slice(-decimalPlaces)}`
+}
+
+export const getTransactionSplitTotals = (transaction) => {
+  const groups = new Map()
+  const splits = transaction?.attributes?.transactions ?? []
+
+  splits.forEach((split) => {
+    const amount = parseAmount(split?.amount)
+    if (!amount) {
+      return
+    }
+
+    const currencyId = getCurrencyValue(split, 'currency_id', 'id')
+    const currencyCode = getCurrencyValue(split, 'currency_code', 'code')
+    const currencySymbol = getCurrencyValue(split, 'currency_symbol', 'symbol')
+    const declaredDecimalPlaces = Number.parseInt(getCurrencyValue(split, 'currency_decimal_places', 'decimal_places'), 10)
+    const decimalPlaces = Math.max(Number.isInteger(declaredDecimalPlaces) ? declaredDecimalPlaces : 0, amount.fraction.length)
+    const key = getCurrencyKey(split)
+
+    if (!groups.has(key)) {
+      groups.set(key, { amounts: [], currencyId, currencyCode, currencySymbol, decimalPlaces })
+    }
+
+    const group = groups.get(key)
+    group.amounts.push(amount)
+    group.decimalPlaces = Math.max(group.decimalPlaces, decimalPlaces)
+  })
+
+  return [...groups.values()].map((group) => {
+    const total = group.amounts.reduce((result, amount) => result + toMinorUnits(amount, group.decimalPlaces), 0n)
+    return {
+      amount: fromMinorUnits(total, group.decimalPlaces),
+      currencyId: group.currencyId,
+      currencyCode: group.currencyCode,
+      currencySymbol: group.currencySymbol,
+      decimalPlaces: group.decimalPlaces,
+    }
+  })
+}


### PR DESCRIPTION
## Why

Firefly Pico’s transaction details view treated a split transaction like a single transaction: it rendered only the first journal. This hid the remaining split lines and their per-line account, category, budget, tags, notes, and attachments, and could silently normalize split descriptions during form initialization.

## What changed

- Detect split transactions from the complete attributes.transactions array rather than only the first journal.
- Render a read-only split view with:
  - Group date, journal type, and split count.
  - A total only when all splits share one currency, otherwise a per-currency total breakdown.
  - Every split’s amount, source/destination accounts, category, budget, tags, notes, references, and location when present.
  - Read-only attachment lists for each split; downloads remain available.
- Preserve lossless decimal amounts using BigInt aggregation and currency precision formatting.
- Skip single-transaction description normalization for split transactions.
- Add translations for the new split-specific UI across all locale files.

## Scope boundaries

This pull request intentionally does not change split editing or creation, mutate Firefly III data, infer missing data, or provide a misleading combined amount for mixed-currency splits.

## Verification

| Check | Result |
| --- | --- |
| Focused split utility tests | PASS — 7/7 |
| Frontend build | PASS |
| Changed-file Prettier validation | PASS |
| Locale JSON parsing | PASS — all 11 locale files |
| Git diff whitespace check | PASS |
| Browser UI review | PASS — mobile/desktop, light/dark, sanitized split fixture |

## UI evidence

Included in #318 

## Compatibility, data, and security

- Read-only rendering only; no backend contract or migration changes.
- Handles arbitrary-precision decimal strings without floating-point coercion.
- Mixed currencies stay separate rather than being silently summed.
- Attachments cannot be uploaded or deleted from split-detail mode; existing downloads remain available.

## Related

Closes #318