### PR TITLE
Show available balance for accounts with virtual balance

### DIFF
--- a/front/components/account/account-adjust-balance.vue
+++ b/front/components/account/account-adjust-balance.vue
@@ -26,6 +26,7 @@ import AccountRepository from '~/repository/AccountRepository.js'
 import AccountTransformer from '~/transformers/AccountTransformer.js'
 import UIUtils from '~/utils/UIUtils.js'
 
+import Account from '~/models/Account.js'
 
 const showDropdown = defineModel('showDropdown', false)
 const popupRef = ref(null)
@@ -51,13 +52,13 @@ const style = computed(() => {
 const emits = defineEmits('result')
 
 watch(showDropdown, (newValue) => {
-  newAmount.value = get(props.value, 'attributes.current_balance')
+  newAmount.value = Account.getBalance(props.value)
 })
 
 const onSave = async () => {
   const accountId = get(props.value, 'id')
   let accountBody = cloneDeep(props.value)
-  const amountOffset = parseFloat(newAmount.value) - parseFloat(get(props.value, 'attributes.current_balance'))
+  const amountOffset = parseFloat(newAmount.value) - parseFloat(Account.getBalance(props.value))
   accountBody.attributes.opening_balance = parseFloat(accountBody.attributes.opening_balance) + amountOffset
   accountBody = AccountTransformer.transformToApi(accountBody)
   const response = await new AccountRepository().update(accountId, accountBody)

--- a/front/components/dashboard/dashboard-accounts/dashboard-accounts.vue
+++ b/front/components/dashboard/dashboard-accounts/dashboard-accounts.vue
@@ -14,6 +14,10 @@
           <div class="display-flex flex-column align-items-center">
             <div class="font-400 text-size-12 text-center text-muted">{{ Account.getDisplayName(account) }}</div>
             <div class="font-700 text-size-12 text-center">{{ getAccountAmount(account) }}</div>
+            <div class="font-400 text-size-11 text-center text-muted">{{ $t('account_page.balance') }}</div>
+            <div v-if="Account.hasVirtualBalance(account)" class="tag-gray app-card-info mt-1 text-size-11 text-center">
+              {{ $t('account_page.available') }}: {{ getAccountAvailableAmount(account) }}
+            </div>
             <div v-if="!Account.getIsIncludedInNetWorth(account)" class="mt-1 font-400 text-size-11 text-center badge-excluded-net-worth">Not in net worth</div>
           </div>
         </template>
@@ -73,6 +77,10 @@ const accountTotal = computed(() => {
 
 const getAccountAmount = (account) => {
   return `${formatNumberForDashboard(Account.getBalance(account))} ${Account.getCurrencySymbol(account)}`
+}
+
+const getAccountAvailableAmount = (account) => {
+  return `${formatNumberForDashboard(Account.getAvailableBalance(account))} ${Account.getCurrencySymbol(account)}`
 }
 
 const hasMultipleCurrencies = computed(() => dashboardStore.dashboardAccountsCurrencyList.length > 1)

--- a/front/components/list-items/account-list-item.vue
+++ b/front/components/list-items/account-list-item.vue
@@ -21,8 +21,9 @@
               <span v-if="accountGroup" class="tag-gray list-item-subtitle">{{ $t('account_page.account_group') }}: {{ accountGroup }}</span>
             </div>
 
-            <div class="display-flex">
+            <div class="display-flex flex-wrap gap-1">
               <span class="tag-gray list-item-subtitle mt-5">{{ $t('account_page.balance') }}: {{ accountBalance }}</span>
+              <span v-if="hasVirtualBalance" class="tag-gray app-card-info list-item-subtitle mt-5">{{ $t('account_page.available') }}: {{ accountAvailableBalance }}</span>
             </div>
           </div>
         </div>
@@ -59,6 +60,8 @@ const accountRole = computed(() => {
 })
 const currencySymbol = computed(() => get(props.value, 'attributes.currency_code'))
 const accountBalance = computed(() => Account.getBalanceWithCurrency(props.value))
+const accountAvailableBalance = computed(() => Account.getAvailableBalanceWithCurrency(props.value))
+const hasVirtualBalance = computed(() => Account.hasVirtualBalance(props.value))
 const icon = computed(() => Account.getIcon(props.value))
 
 const onEdit = async (e) => {

--- a/front/i18n/locales/de-DE.json
+++ b/front/i18n/locales/de-DE.json
@@ -391,6 +391,7 @@
     "include_net_worth": "Im Nettovermögen enthalten",
     "visible_on_dashboard": "Im Dashboard ersichtlich",
     "balance": "Kontostand",
+    "available": "Verfügbar",
     "account_group": "Gruppe"
   },
   "transaction_template_page": {

--- a/front/i18n/locales/en.json
+++ b/front/i18n/locales/en.json
@@ -391,6 +391,7 @@
     "include_net_worth": "Is included in net worth",
     "visible_on_dashboard": "Is visible on Dashboard",
     "balance": "Balance",
+    "available": "Available",
     "account_group": "Group"
   },
   "transaction_template_page": {

--- a/front/i18n/locales/es-MX.json
+++ b/front/i18n/locales/es-MX.json
@@ -390,6 +390,7 @@
     "include_net_worth": "Incluir en el patrimonio neto",
     "visible_on_dashboard": "Visible en el panel principal",
     "balance": "Saldo",
+    "available": "Disponible",
     "account_group": "Grupo"
   },
   "transaction_template_page": {

--- a/front/i18n/locales/fr.json
+++ b/front/i18n/locales/fr.json
@@ -390,6 +390,7 @@
     "include_net_worth": "Est inclus dans la valeur nette",
     "visible_on_dashboard": "Est visible sur le tableau de bord",
     "balance": "Solde",
+    "available": "Disponible",
     "account_group": "Groupe"
   },
   "transaction_template_page": {

--- a/front/i18n/locales/it.json
+++ b/front/i18n/locales/it.json
@@ -390,6 +390,7 @@
     "include_net_worth": "Incluso nel patrimonio netto",
     "visible_on_dashboard": "Visibile nella Dashboard",
     "balance": "Saldo",
+    "available": "Disponibile",
     "account_group": "Gruppo"
   },
   "transaction_template_page": {

--- a/front/i18n/locales/ko.json
+++ b/front/i18n/locales/ko.json
@@ -391,6 +391,7 @@
     "include_net_worth": "순자산에 포함",
     "visible_on_dashboard": "대시보드에 표시",
     "balance": "잔액",
+    "available": "사용 가능",
     "account_group": "그룹"
   },
   "transaction_template_page": {

--- a/front/i18n/locales/pl.json
+++ b/front/i18n/locales/pl.json
@@ -390,6 +390,7 @@
     "include_net_worth": "Jest uwzględnione w wartości netto",
     "visible_on_dashboard": "Jest widoczne na pulpicie nawigacyjnym",
     "balance": "Saldo",
+    "available": "Dostępne",
     "account_group": "Grupa"
   },
   "transaction_template_page": {

--- a/front/i18n/locales/pt-BR.json
+++ b/front/i18n/locales/pt-BR.json
@@ -390,6 +390,7 @@
     "include_net_worth": "Está incluído no patrimônio líquido",
     "visible_on_dashboard": "Está visível no Painel",
     "balance": "Saldo",
+    "available": "Disponível",
     "account_group": "Grupo"
   },
   "transaction_template_page": {

--- a/front/i18n/locales/ro.json
+++ b/front/i18n/locales/ro.json
@@ -390,6 +390,7 @@
     "include_net_worth": "Include în averea netă",
     "visible_on_dashboard": "Este vizibil pe Dashboard",
     "balance": "Total",
+    "available": "Disponibil",
     "account_group": "Grup"
   },
   "transaction_template_page": {

--- a/front/i18n/locales/ru-RU.json
+++ b/front/i18n/locales/ru-RU.json
@@ -390,6 +390,7 @@
     "include_net_worth": "Включать в чистый капитал",
     "visible_on_dashboard": "Виден на дашборде",
     "balance": "Баланс",
+    "available": "Доступно",
     "account_group": "Группа"
   },
   "transaction_template_page": {

--- a/front/i18n/locales/zh-CN.json
+++ b/front/i18n/locales/zh-CN.json
@@ -372,6 +372,7 @@
     "include_net_worth": "是否计入净资产",
     "visible_on_dashboard": "是否在仪表板上显示",
     "balance": "平衡",
+    "available": "可用",
     "account_group": "组"
   },
   "transaction_template_page": {

--- a/front/models/Account.js
+++ b/front/models/Account.js
@@ -6,6 +6,7 @@ import { get } from 'lodash-es'
 import Transaction from '~/models/Transaction'
 import { NUMBER_FORMAT } from '~/utils/NumberUtils.js'
 import Currency from '~/models/Currency.js'
+import { getBalanceWithoutVirtual, hasVirtualBalance } from '~/utils/AccountBalanceUtils.js'
 
 export default class Account extends BaseModel {
   getTransformer() {
@@ -228,14 +229,25 @@ export default class Account extends BaseModel {
   }
 
   static getBalance(account) {
+    return getBalanceWithoutVirtual(this.getAvailableBalance(account), this.getVirtualBalance(account))
+  }
+
+  static getAvailableBalance(account) {
     return get(account, 'attributes.current_balance')
   }
 
-  static getBalanceWithCurrency(account) {
+  static getVirtualBalance(account) {
+    return get(account, 'attributes.virtual_balance')
+  }
+
+  static hasVirtualBalance(account) {
+    return hasVirtualBalance(this.getVirtualBalance(account))
+  }
+
+  static getAmountWithCurrency(account, amount) {
     const profileStore = useProfileStore()
     let digits = profileStore.dashboard.showDecimal ? 2 : 0
     let numberFormatCode = profileStore.numberFormat.code ?? NUMBER_FORMAT.eu.code
-    let amount = this.getBalance(account)
     amount = new Intl.NumberFormat(numberFormatCode, {
       minimumFractionDigits: digits,
       maximumFractionDigits: digits,
@@ -243,6 +255,14 @@ export default class Account extends BaseModel {
 
     let currency = this.getCurrencySymbol(account)
     return [amount, currency].filter((item) => !!item).join(' ')
+  }
+
+  static getBalanceWithCurrency(account) {
+    return this.getAmountWithCurrency(account, this.getBalance(account))
+  }
+
+  static getAvailableBalanceWithCurrency(account) {
+    return this.getAmountWithCurrency(account, this.getAvailableBalance(account))
   }
 
   static getIsActive(account) {

--- a/front/pages/accounts/[[id]].vue
+++ b/front/pages/accounts/[[id]].vue
@@ -133,7 +133,7 @@ watch(name, (newValue) => {
   name.value = newValue
 })
 
-const accountBalance = computed(() => get(item.value, 'attributes.current_balance'))
+const accountBalance = computed(() => Account.getBalance(item.value))
 const accountCurrency = computed(() => get(item.value, 'attributes.currency_symbol') ?? '')
 const adjustBalanceText = computed(() => `${t('account_page.adjust_balance')} (${accountBalance.value} ${accountCurrency.value})`)
 const onAdjustBalance = () => {

--- a/front/stores/dashboardStore.js
+++ b/front/stores/dashboardStore.js
@@ -179,7 +179,7 @@ export const useDashboardStore = defineStore('dashboard', () => {
   const dashboardAccountsTotalByCurrency = computed(() => {
     return dashboardAccountsInNetWorth.value.reduce((result, account) => {
       let accountCurrency = account?.attributes?.currency_code
-      const accountBalance = parseFloat(account?.attributes?.current_balance ?? 0)
+      const accountBalance = parseFloat(Account.getBalance(account) ?? 0)
       let oldValue = result[accountCurrency] ?? 0
       result[accountCurrency] = oldValue + accountBalance
       return result
@@ -201,7 +201,7 @@ export const useDashboardStore = defineStore('dashboard', () => {
     return dashboardAccountsInNetWorth.value.reduce((result, account) => {
       let group = account?.attributes?.group
       if (!group) return result
-      let accountBalance = parseFloat(account?.attributes?.current_balance ?? 0)
+      let accountBalance = parseFloat(Account.getBalance(account) ?? 0)
       accountBalance = convertCurrency(accountBalance, Account.getCurrencyCode(account), Currency.getCode(dashboardCurrency.value))
 
       let oldValue = result[group] ?? 0

--- a/front/tests/utils/AccountBalanceUtils.test.js
+++ b/front/tests/utils/AccountBalanceUtils.test.js
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { getBalanceWithoutVirtual, hasVirtualBalance } from '../../utils/AccountBalanceUtils.js'
+
+test('derives the booked balance for secured credit card collateral', () => {
+  assert.equal(getBalanceWithoutVirtual('-100', '-500'), 400)
+})
+
+test('derives the booked balance when virtual balance represents a credit limit', () => {
+  assert.equal(getBalanceWithoutVirtual('39000', '40000'), -1000)
+})
+
+test('preserves decimal account balances', () => {
+  assert.equal(getBalanceWithoutVirtual('290.99', '500'), -209.01)
+})
+
+test('uses current balance when no virtual balance is set', () => {
+  assert.equal(getBalanceWithoutVirtual('125.50', '0'), 125.5)
+  assert.equal(getBalanceWithoutVirtual('125.50', null), 125.5)
+  assert.equal(getBalanceWithoutVirtual('125.50'), 125.5)
+})
+
+test('preserves a missing or invalid current balance', () => {
+  assert.equal(getBalanceWithoutVirtual(null, '-500'), null)
+  assert.equal(getBalanceWithoutVirtual(undefined, '-500'), undefined)
+  assert.equal(getBalanceWithoutVirtual('unknown', '-500'), 'unknown')
+})
+
+test('shows Available only for a non-zero numeric virtual balance', () => {
+  assert.equal(hasVirtualBalance('-500'), true)
+  assert.equal(hasVirtualBalance('40000'), true)
+  assert.equal(hasVirtualBalance('0'), false)
+  assert.equal(hasVirtualBalance('0.00'), false)
+  assert.equal(hasVirtualBalance(''), false)
+  assert.equal(hasVirtualBalance(null), false)
+  assert.equal(hasVirtualBalance(undefined), false)
+  assert.equal(hasVirtualBalance('unknown'), false)
+})

--- a/front/utils/AccountBalanceUtils.js
+++ b/front/utils/AccountBalanceUtils.js
@@ -1,0 +1,28 @@
+const hasAmount = (value) => value !== null && value !== undefined && value !== ''
+
+export const hasVirtualBalance = (virtualBalance) => {
+  if (!hasAmount(virtualBalance)) {
+    return false
+  }
+
+  const amount = Number(virtualBalance)
+  return Number.isFinite(amount) && amount !== 0
+}
+
+export const getBalanceWithoutVirtual = (currentBalance, virtualBalance) => {
+  if (!hasAmount(currentBalance)) {
+    return currentBalance
+  }
+
+  const currentAmount = Number(currentBalance)
+  if (!Number.isFinite(currentAmount)) {
+    return currentBalance
+  }
+
+  const virtualAmount = hasAmount(virtualBalance) ? Number(virtualBalance) : 0
+  if (!Number.isFinite(virtualAmount)) {
+    return currentAmount
+  }
+
+  return Number((currentAmount - virtualAmount).toFixed(12))
+}


### PR DESCRIPTION
Closes #321.

Available is Balance plus Firefly III's virtual balance. It keeps secured-card collateral out of usable funds and turns a virtual credit limit into remaining credit.

Available is shown beside Balance when an account has a non-zero virtual balance. Dashboard totals and balance adjustments still use Balance.

Light theme

<img width="1062" height="296" alt="image" src="https://github.com/user-attachments/assets/8e2df1a8-7f4f-4fbf-8fee-7b4a0a9f5023" />


Dark theme

<img width="1057" height="305" alt="image" src="https://github.com/user-attachments/assets/7b1159c2-a0f7-481c-9afc-3237a2d3da06" />


Checks: 6 balance tests and production build pass.