### PR TITLE
Fix changing transaction type in edit form

### DIFF
--- a/front/composables/useTransactionForm.js
+++ b/front/composables/useTransactionForm.js
@@ -122,11 +122,10 @@ export const useTransactionForm = ({ item, itemId, profileStore = useProfileStor
     }
   })
 
-  watch(type, (newValue, oldValue) => {
-    // Only react to real user-driven tab switches on the new-transaction form.
-    // On initial form population, oldValue is undefined and the saved defaults
-    // are still being settled — running the repair there silently dropped them.
-    if (itemId.value || !oldValue || isEqual(newValue, oldValue)) {
+  watch([item, type], ([currentItem, newValue], [previousItem, oldValue]) => {
+    // Ignore form hydration, but repair account directions after a user changes
+    // the type of a non-split transaction, including an existing one.
+    if (currentItem !== previousItem || isSplitTransaction.value || !oldValue || isEqual(newValue, oldValue)) {
       return
     }
     attemptAccountsFix()

--- a/front/transformers/TransactionTransformer.js
+++ b/front/transformers/TransactionTransformer.js
@@ -81,7 +81,7 @@ export default class TransactionTransformer extends ApiTransformer {
         category_id: get(transaction, 'category.id') ?? null,
         budget_id: get(transaction, 'budget.id') ?? 0,
         date: DateUtils.dateToString(transaction.date, DateUtils.FORMAT_ENGLISH_DATE_HOUR_MINUTE),
-        type: Transaction.getTransactionTypeForAccounts({ source: accountSource, destination: accountDestination }).fireflyCode,
+        type: get(transaction, 'type.fireflyCode'),
       }
 
       // Send null when unset so clearing an extra date in the form also clears it in Firefly


### PR DESCRIPTION
## What

Preserve the type selected in the transaction form when sending an update.

## Why

Previously the transformer inferred the type from the source/destination accounts. Editing an existing transaction and selecting Income or Expense could therefore report success while retaining the original type.

The form now repairs account direction for genuine type changes on non-split transactions, including existing transactions. Split transactions remain unchanged.

## Verification

- Switch an existing non-split transaction between Expense and Income.
- Confirm the compatible account is retained in the appropriate source/destination field.
- Save and reload: the selected type is retained.

`node --check` passes for both changed front-end modules.